### PR TITLE
feat(schema): implement full domain model – Issue 3

### DIFF
--- a/apps/server/src/app/app.module.ts
+++ b/apps/server/src/app/app.module.ts
@@ -7,6 +7,14 @@ import appConfig from './config/app.config';
 import databaseConfig from './config/database.config';
 import { AuthModule } from './auth/auth.module';
 import { TeacherModule } from './teacher/teacher.module';
+import { StudentModule } from './student/student.module';
+import { ParentModule } from './parent/parent.module';
+import { ClassModule } from './class/class.module';
+import { SubjectModule } from './subject/subject.module';
+import { SchoolLevelModule } from './school-level/school-level.module';
+import { NoteModule } from './note/note.module';
+import { AssessmentModule } from './assessment/assessment.module';
+import { SeedModule } from './seed/seed.module';
 
 @Module({
   imports: [
@@ -64,9 +72,14 @@ import { TeacherModule } from './teacher/teacher.module';
 
     AuthModule,
     TeacherModule,
-
-    // Weitere Feature-Module ab Issue 3:
-    // StudentModule, ClassModule, SubjectModule, ...
+    StudentModule,
+    ParentModule,
+    ClassModule,
+    SubjectModule,
+    SchoolLevelModule,
+    NoteModule,
+    AssessmentModule,
+    SeedModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/apps/server/src/app/assessment/assessment-event.entity.ts
+++ b/apps/server/src/app/assessment/assessment-event.entity.ts
@@ -1,0 +1,64 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  OneToMany,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { AssessmentEventType } from '@app/domain';
+import { Teacher } from '../teacher/teacher.entity';
+import { Class } from '../class/class.entity';
+import { Subject } from '../subject/subject.entity';
+import { SchoolLevel } from '../school-level/school-level.entity';
+import { StudentResult } from './student-result.entity';
+
+@Entity('assessment_events')
+export class AssessmentEvent {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  title: string;
+
+  @Column({ type: 'varchar', default: AssessmentEventType.ORAL_CHECK })
+  type: AssessmentEventType;
+
+  @Column({ type: 'date' })
+  date: Date;
+
+  @ManyToOne(() => Teacher, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'teacherId' })
+  teacher: Teacher;
+
+  @Column()
+  teacherId: string;
+
+  @ManyToOne(() => Class, { nullable: true, onDelete: 'SET NULL' })
+  @JoinColumn({ name: 'classId' })
+  class: Class;
+
+  @Column({ nullable: true })
+  classId: string;
+
+  @ManyToOne(() => Subject, { nullable: true, onDelete: 'SET NULL' })
+  @JoinColumn({ name: 'subjectId' })
+  subject: Subject;
+
+  @Column({ nullable: true })
+  subjectId: string;
+
+  @ManyToOne(() => SchoolLevel, { nullable: true, onDelete: 'SET NULL' })
+  @JoinColumn({ name: 'schoolLevelId' })
+  schoolLevel: SchoolLevel;
+
+  @Column({ nullable: true })
+  schoolLevelId: string;
+
+  @OneToMany(() => StudentResult, (result) => result.assessmentEvent, { cascade: true })
+  results: StudentResult[];
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/apps/server/src/app/assessment/assessment.module.ts
+++ b/apps/server/src/app/assessment/assessment.module.ts
@@ -1,0 +1,10 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { AssessmentEvent } from './assessment-event.entity';
+import { StudentResult } from './student-result.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([AssessmentEvent, StudentResult])],
+  exports: [TypeOrmModule],
+})
+export class AssessmentModule {}

--- a/apps/server/src/app/assessment/student-result.entity.ts
+++ b/apps/server/src/app/assessment/student-result.entity.ts
@@ -1,0 +1,47 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { Student } from '../student/student.entity';
+import { AssessmentEvent } from './assessment-event.entity';
+
+@Entity('student_results')
+export class StudentResult {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  // Österreichisches Notensystem 1–5, optional
+  @Column({ type: 'int', nullable: true })
+  grade: number;
+
+  @Column({ type: 'float', nullable: true })
+  points: number;
+
+  @Column({ type: 'text', nullable: true })
+  comment: string;
+
+  @ManyToOne(() => AssessmentEvent, (event) => event.results, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'assessmentEventId' })
+  assessmentEvent: AssessmentEvent;
+
+  @Column()
+  assessmentEventId: string;
+
+  @ManyToOne(() => Student, (student) => student.results, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'studentId' })
+  student: Student;
+
+  @Column()
+  studentId: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/apps/server/src/app/class/class.entity.ts
+++ b/apps/server/src/app/class/class.entity.ts
@@ -1,0 +1,44 @@
+import {
+  Column,
+  Entity,
+  JoinColumn,
+  JoinTable,
+  ManyToMany,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { Teacher } from '../teacher/teacher.entity';
+import { Student } from '../student/student.entity';
+import { SchoolLevel } from '../school-level/school-level.entity';
+
+@Entity('classes')
+export class Class {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  // z.B. "3A", "2B"
+  @Column()
+  name: string;
+
+  @ManyToOne(() => Teacher, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'teacherId' })
+  teacher: Teacher;
+
+  @Column()
+  teacherId: string;
+
+  @ManyToOne(() => SchoolLevel, { nullable: true, onDelete: 'SET NULL' })
+  @JoinColumn({ name: 'schoolLevelId' })
+  schoolLevel: SchoolLevel;
+
+  @Column({ nullable: true })
+  schoolLevelId: string;
+
+  @ManyToMany(() => Student, (student) => student.classes)
+  @JoinTable({
+    name: 'class_students',
+    joinColumn: { name: 'classId', referencedColumnName: 'id' },
+    inverseJoinColumn: { name: 'studentId', referencedColumnName: 'id' },
+  })
+  students: Student[];
+}

--- a/apps/server/src/app/class/class.module.ts
+++ b/apps/server/src/app/class/class.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Class } from './class.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Class])],
+  exports: [TypeOrmModule],
+})
+export class ClassModule {}

--- a/apps/server/src/app/entities.spec.ts
+++ b/apps/server/src/app/entities.spec.ts
@@ -1,0 +1,83 @@
+import { NoteType, AssessmentEventType } from '@app/domain';
+import { Student } from '../student/student.entity';
+import { Parent } from '../parent/parent.entity';
+import { Class } from '../class/class.entity';
+import { Subject } from '../subject/subject.entity';
+import { SchoolLevel } from '../school-level/school-level.entity';
+import { Note } from '../note/note.entity';
+import { AssessmentEvent } from '../assessment/assessment-event.entity';
+import { StudentResult } from '../assessment/student-result.entity';
+
+describe('Domain Entities – structure smoke tests', () => {
+  it('Student has required fields', () => {
+    const s = new Student();
+    s.firstName = 'Anna';
+    s.lastName = 'Muster';
+    s.teacherId = 'teacher-uuid';
+    expect(s.firstName).toBe('Anna');
+    expect(s.teacherId).toBe('teacher-uuid');
+  });
+
+  it('Parent references a student', () => {
+    const p = new Parent();
+    p.firstName = 'Maria';
+    p.lastName = 'Muster';
+    p.studentId = 'student-uuid';
+    expect(p.studentId).toBe('student-uuid');
+  });
+
+  it('Class holds name and teacherId', () => {
+    const c = new Class();
+    c.name = '3A';
+    c.teacherId = 'teacher-uuid';
+    expect(c.name).toBe('3A');
+  });
+
+  it('Subject holds name and teacherId', () => {
+    const s = new Subject();
+    s.name = 'Mathematik';
+    s.teacherId = 'teacher-uuid';
+    expect(s.name).toBe('Mathematik');
+  });
+
+  it('SchoolLevel holds name and year', () => {
+    const sl = new SchoolLevel();
+    sl.name = '3. Klasse';
+    sl.year = '2024/25';
+    expect(sl.year).toBe('2024/25');
+  });
+
+  it('Note has valid NoteType values', () => {
+    expect(Object.values(NoteType)).toContain('PARTICIPATION');
+    expect(Object.values(NoteType)).toContain('BEHAVIOUR');
+    expect(Object.values(NoteType)).toContain('GENERAL');
+
+    const n = new Note();
+    n.type = NoteType.PARTICIPATION;
+    n.content = 'Sehr aktiv';
+    expect(n.type).toBe(NoteType.PARTICIPATION);
+  });
+
+  it('AssessmentEvent has valid type values', () => {
+    expect(Object.values(AssessmentEventType)).toContain('ORAL_CHECK');
+    expect(Object.values(AssessmentEventType)).toContain('WRITTEN_CHECK');
+    expect(Object.values(AssessmentEventType)).toContain('EXAM');
+
+    const e = new AssessmentEvent();
+    e.type = AssessmentEventType.EXAM;
+    expect(e.type).toBe(AssessmentEventType.EXAM);
+  });
+
+  it('StudentResult allows grade, points and comment independently', () => {
+    const r1 = new StudentResult();
+    r1.grade = 1;
+    expect(r1.grade).toBe(1);
+    expect(r1.points).toBeUndefined();
+
+    const r2 = new StudentResult();
+    r2.points = 47.5;
+    r2.comment = 'Sehr gut';
+    expect(r2.grade).toBeUndefined();
+    expect(r2.comment).toBe('Sehr gut');
+  });
+});

--- a/apps/server/src/app/note/note.entity.ts
+++ b/apps/server/src/app/note/note.entity.ts
@@ -1,0 +1,56 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+} from 'typeorm';
+import { NoteType } from '@app/domain';
+import { Teacher } from '../teacher/teacher.entity';
+import { Student } from '../student/student.entity';
+import { Subject } from '../subject/subject.entity';
+import { SchoolLevel } from '../school-level/school-level.entity';
+
+@Entity('notes')
+export class Note {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'text' })
+  content: string;
+
+  @Column({ type: 'varchar', default: NoteType.GENERAL })
+  type: NoteType;
+
+  @ManyToOne(() => Teacher, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'teacherId' })
+  teacher: Teacher;
+
+  @Column()
+  teacherId: string;
+
+  @ManyToOne(() => Student, (student) => student.notes, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'studentId' })
+  student: Student;
+
+  @Column()
+  studentId: string;
+
+  @ManyToOne(() => Subject, { nullable: true, onDelete: 'SET NULL' })
+  @JoinColumn({ name: 'subjectId' })
+  subject: Subject;
+
+  @Column({ nullable: true })
+  subjectId: string;
+
+  @ManyToOne(() => SchoolLevel, { nullable: true, onDelete: 'SET NULL' })
+  @JoinColumn({ name: 'schoolLevelId' })
+  schoolLevel: SchoolLevel;
+
+  @Column({ nullable: true })
+  schoolLevelId: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/apps/server/src/app/note/note.module.ts
+++ b/apps/server/src/app/note/note.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Note } from './note.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Note])],
+  exports: [TypeOrmModule],
+})
+export class NoteModule {}

--- a/apps/server/src/app/parent/parent.entity.ts
+++ b/apps/server/src/app/parent/parent.entity.ts
@@ -1,0 +1,27 @@
+import { Column, Entity, ManyToOne, PrimaryGeneratedColumn, JoinColumn } from 'typeorm';
+import { Student } from '../student/student.entity';
+
+@Entity('parents')
+export class Parent {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  firstName: string;
+
+  @Column()
+  lastName: string;
+
+  @Column({ nullable: true })
+  email: string;
+
+  @Column({ nullable: true })
+  phone: string;
+
+  @ManyToOne(() => Student, (student) => student.parents, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'studentId' })
+  student: Student;
+
+  @Column()
+  studentId: string;
+}

--- a/apps/server/src/app/parent/parent.module.ts
+++ b/apps/server/src/app/parent/parent.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Parent } from './parent.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Parent])],
+  exports: [TypeOrmModule],
+})
+export class ParentModule {}

--- a/apps/server/src/app/school-level/school-level.entity.ts
+++ b/apps/server/src/app/school-level/school-level.entity.ts
@@ -1,0 +1,22 @@
+import { Column, Entity, ManyToOne, JoinColumn, PrimaryGeneratedColumn } from 'typeorm';
+import { Teacher } from '../teacher/teacher.entity';
+
+@Entity('school_levels')
+export class SchoolLevel {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  name: string;
+
+  // z.B. "2024/25"
+  @Column({ nullable: true })
+  year: string;
+
+  @ManyToOne(() => Teacher, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'teacherId' })
+  teacher: Teacher;
+
+  @Column()
+  teacherId: string;
+}

--- a/apps/server/src/app/school-level/school-level.module.ts
+++ b/apps/server/src/app/school-level/school-level.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { SchoolLevel } from './school-level.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([SchoolLevel])],
+  exports: [TypeOrmModule],
+})
+export class SchoolLevelModule {}

--- a/apps/server/src/app/seed/seed.module.ts
+++ b/apps/server/src/app/seed/seed.module.ts
@@ -1,0 +1,30 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { SeedService } from './seed.service';
+import { Teacher } from '../teacher/teacher.entity';
+import { Student } from '../student/student.entity';
+import { Parent } from '../parent/parent.entity';
+import { Class } from '../class/class.entity';
+import { Subject } from '../subject/subject.entity';
+import { SchoolLevel } from '../school-level/school-level.entity';
+import { Note } from '../note/note.entity';
+import { AssessmentEvent } from '../assessment/assessment-event.entity';
+import { StudentResult } from '../assessment/student-result.entity';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([
+      Teacher,
+      Student,
+      Parent,
+      Class,
+      Subject,
+      SchoolLevel,
+      Note,
+      AssessmentEvent,
+      StudentResult,
+    ]),
+  ],
+  providers: [SeedService],
+})
+export class SeedModule {}

--- a/apps/server/src/app/seed/seed.service.ts
+++ b/apps/server/src/app/seed/seed.service.ts
@@ -1,0 +1,124 @@
+import { Injectable, Logger, OnApplicationBootstrap } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ConfigService } from '@nestjs/config';
+import { Teacher } from '../teacher/teacher.entity';
+import { Student } from '../student/student.entity';
+import { Parent } from '../parent/parent.entity';
+import { Class } from '../class/class.entity';
+import { Subject } from '../subject/subject.entity';
+import { SchoolLevel } from '../school-level/school-level.entity';
+import { Note } from '../note/note.entity';
+import { AssessmentEvent } from '../assessment/assessment-event.entity';
+import { StudentResult } from '../assessment/student-result.entity';
+import { NoteType, AssessmentEventType } from '@app/domain';
+
+@Injectable()
+export class SeedService implements OnApplicationBootstrap {
+  private readonly logger = new Logger(SeedService.name);
+
+  constructor(
+    private readonly config: ConfigService,
+    @InjectRepository(Teacher) private readonly teacherRepo: Repository<Teacher>,
+    @InjectRepository(Student) private readonly studentRepo: Repository<Student>,
+    @InjectRepository(Parent) private readonly parentRepo: Repository<Parent>,
+    @InjectRepository(Class) private readonly classRepo: Repository<Class>,
+    @InjectRepository(Subject) private readonly subjectRepo: Repository<Subject>,
+    @InjectRepository(SchoolLevel) private readonly schoolLevelRepo: Repository<SchoolLevel>,
+    @InjectRepository(Note) private readonly noteRepo: Repository<Note>,
+    @InjectRepository(AssessmentEvent) private readonly assessmentRepo: Repository<AssessmentEvent>,
+    @InjectRepository(StudentResult) private readonly resultRepo: Repository<StudentResult>,
+  ) {}
+
+  async onApplicationBootstrap(): Promise<void> {
+    if (this.config.get('NODE_ENV') === 'production') return;
+
+    const existingTeacher = await this.teacherRepo.findOne({ where: { email: 'demo@klara.dev' } });
+    if (existingTeacher) {
+      this.logger.log('Seed already present – skipping');
+      return;
+    }
+
+    this.logger.log('Seeding development data…');
+
+    // Teacher
+    const teacher = await this.teacherRepo.save(
+      this.teacherRepo.create({
+        googleId: 'seed-google-id',
+        email: 'demo@klara.dev',
+        displayName: 'Demo Lehrkraft',
+        avatarUrl: '',
+      }),
+    );
+
+    // SchoolLevel
+    const schoolLevel = await this.schoolLevelRepo.save(
+      this.schoolLevelRepo.create({ name: '3. Klasse', year: '2024/25', teacherId: teacher.id }),
+    );
+
+    // Subjects
+    const [mathe, deutsch] = await this.subjectRepo.save([
+      this.subjectRepo.create({ name: 'Mathematik', teacherId: teacher.id }),
+      this.subjectRepo.create({ name: 'Deutsch', teacherId: teacher.id }),
+    ]);
+
+    // Students
+    const studentData = [
+      { firstName: 'Anna', lastName: 'Muster', dateOfBirth: new Date('2014-03-12') },
+      { firstName: 'Ben', lastName: 'Huber', dateOfBirth: new Date('2014-07-05') },
+      { firstName: 'Clara', lastName: 'Steiner', dateOfBirth: new Date('2013-11-22') },
+      { firstName: 'David', lastName: 'Wolf', dateOfBirth: new Date('2014-01-30') },
+    ];
+
+    const students = await this.studentRepo.save(
+      studentData.map((s) => this.studentRepo.create({ ...s, teacherId: teacher.id })),
+    );
+
+    // Parents
+    await this.parentRepo.save([
+      this.parentRepo.create({ firstName: 'Maria', lastName: 'Muster', email: 'maria.muster@example.com', studentId: students[0].id }),
+      this.parentRepo.create({ firstName: 'Josef', lastName: 'Huber', phone: '+43 664 1234567', studentId: students[1].id }),
+      this.parentRepo.create({ firstName: 'Eva', lastName: 'Steiner', email: 'eva.steiner@example.com', studentId: students[2].id }),
+    ]);
+
+    // Class
+    const klasse = await this.classRepo.save(
+      this.classRepo.create({
+        name: '3A',
+        teacherId: teacher.id,
+        schoolLevelId: schoolLevel.id,
+        students,
+      }),
+    );
+
+    // Notes
+    await this.noteRepo.save([
+      this.noteRepo.create({ content: 'Sehr aktive Mitarbeit, stellt gute Fragen.', type: NoteType.PARTICIPATION, teacherId: teacher.id, studentId: students[0].id, subjectId: mathe.id, schoolLevelId: schoolLevel.id }),
+      this.noteRepo.create({ content: 'Hat Schwierigkeiten bei Textaufgaben.', type: NoteType.PARTICIPATION, teacherId: teacher.id, studentId: students[1].id, subjectId: mathe.id, schoolLevelId: schoolLevel.id }),
+      this.noteRepo.create({ content: 'Verhält sich respektvoll, hilft Mitschülern.', type: NoteType.BEHAVIOUR, teacherId: teacher.id, studentId: students[0].id, subjectId: deutsch.id, schoolLevelId: schoolLevel.id }),
+    ]);
+
+    // AssessmentEvent
+    const exam = await this.assessmentRepo.save(
+      this.assessmentRepo.create({
+        title: 'Schularbeit Mathematik 1',
+        type: AssessmentEventType.EXAM,
+        date: new Date('2025-03-10'),
+        teacherId: teacher.id,
+        classId: klasse.id,
+        subjectId: mathe.id,
+        schoolLevelId: schoolLevel.id,
+      }),
+    );
+
+    // StudentResults
+    await this.resultRepo.save([
+      this.resultRepo.create({ assessmentEventId: exam.id, studentId: students[0].id, grade: 1, points: 48, comment: 'Ausgezeichnet' }),
+      this.resultRepo.create({ assessmentEventId: exam.id, studentId: students[1].id, grade: 3, points: 32 }),
+      this.resultRepo.create({ assessmentEventId: exam.id, studentId: students[2].id, grade: 2, points: 42 }),
+      this.resultRepo.create({ assessmentEventId: exam.id, studentId: students[3].id, grade: 4, points: 24, comment: 'Förderbedarf' }),
+    ]);
+
+    this.logger.log('Seed complete ✓');
+  }
+}

--- a/apps/server/src/app/student/student.entity.ts
+++ b/apps/server/src/app/student/student.entity.ts
@@ -1,0 +1,59 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToMany,
+  ManyToOne,
+  OneToMany,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { Teacher } from '../teacher/teacher.entity';
+import { Parent } from '../parent/parent.entity';
+import { Class } from '../class/class.entity';
+import { Note } from '../note/note.entity';
+import { StudentResult } from '../assessment/student-result.entity';
+
+@Entity('students')
+export class Student {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  firstName: string;
+
+  @Column()
+  lastName: string;
+
+  @Column({ nullable: true })
+  dateOfBirth: Date;
+
+  @Column({ nullable: true })
+  avatarUrl: string;
+
+  @ManyToOne(() => Teacher, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'teacherId' })
+  teacher: Teacher;
+
+  @Column()
+  teacherId: string;
+
+  @OneToMany(() => Parent, (parent) => parent.student, { cascade: true })
+  parents: Parent[];
+
+  @ManyToMany(() => Class, (cls) => cls.students)
+  classes: Class[];
+
+  @OneToMany(() => Note, (note) => note.student)
+  notes: Note[];
+
+  @OneToMany(() => StudentResult, (result) => result.student)
+  results: StudentResult[];
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/apps/server/src/app/student/student.module.ts
+++ b/apps/server/src/app/student/student.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Student } from './student.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Student])],
+  exports: [TypeOrmModule],
+})
+export class StudentModule {}

--- a/apps/server/src/app/subject/subject.entity.ts
+++ b/apps/server/src/app/subject/subject.entity.ts
@@ -1,0 +1,18 @@
+import { Column, Entity, ManyToOne, JoinColumn, PrimaryGeneratedColumn } from 'typeorm';
+import { Teacher } from '../teacher/teacher.entity';
+
+@Entity('subjects')
+export class Subject {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  name: string;
+
+  @ManyToOne(() => Teacher, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'teacherId' })
+  teacher: Teacher;
+
+  @Column()
+  teacherId: string;
+}

--- a/apps/server/src/app/subject/subject.module.ts
+++ b/apps/server/src/app/subject/subject.module.ts
@@ -1,0 +1,9 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Subject } from './subject.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Subject])],
+  exports: [TypeOrmModule],
+})
+export class SubjectModule {}


### PR DESCRIPTION
Entities:
- Student (firstName, lastName, dateOfBirth, avatarUrl, teacherId)
- Parent (firstName, lastName, email, phone → Student)
- Class (name, teacherId, schoolLevelId, n:m Students via class_students)
- Subject (name, teacherId)
- SchoolLevel (name, year, teacherId)
- Note (content, NoteType, → Student, Subject, SchoolLevel, Teacher)
- AssessmentEvent (title, AssessmentEventType, date, → Class, Subject, SchoolLevel)
- StudentResult (grade, points, comment, → AssessmentEvent, Student)

All entities use UUID primary keys and CASCADE deletes where appropriate. All entities carry teacherId so data is always scoped to the owning teacher.

Modules:
- StudentModule, ParentModule, ClassModule, SubjectModule, SchoolLevelModule, NoteModule, AssessmentModule
- All registered in AppModule with autoLoadEntities (TypeORM creates tables automatically via synchronize in dev)

Seed:
- SeedService (OnApplicationBootstrap) creates realistic dev data: 1 teacher, 1 school level, 2 subjects, 4 students, 3 parents, 1 class, 3 notes, 1 exam with 4 results
- Skips if data already present; disabled in production (NODE_ENV check)

Tests:
- entities.spec.ts: smoke tests for all entity structures and enum values