### PR TITLE
feat(9+10): Leistungsdokumentation – Backend API + Frontend

### DIFF
--- a/apps/klara/src/app/app.routes.ts
+++ b/apps/klara/src/app/app.routes.ts
@@ -27,6 +27,8 @@ export const appRoutes: Route[] = [
     canActivate: [authGuard],
     children: [
       { path: '', component: HomeComponent, title: 'Klara' },
+      { path: 'assessments',       loadComponent: () => import('./features/assessments/assessment-list.component').then(m => m.AssessmentListComponent),   title: 'Leistungen – Klara' },
+      { path: 'assessments/:id',    loadComponent: () => import('./features/assessments/assessment-detail.component').then(m => m.AssessmentDetailComponent), title: 'Leistung – Klara' },
       { path: 'notes',           loadComponent: () => import('./features/notes/notes-page.component').then(m => m.NotesPageComponent),             title: 'Notizen – Klara' },
       { path: 'students',        loadComponent: () => import('./features/students/list/student-list.component').then(m => m.StudentListComponent),   title: 'Schüler – Klara' },
       { path: 'students/new',    loadComponent: () => import('./features/students/form/student-form.component').then(m => m.StudentFormComponent),   title: 'Neuer Schüler – Klara' },

--- a/apps/klara/src/app/features/assessments/assessment-detail.component.ts
+++ b/apps/klara/src/app/features/assessments/assessment-detail.component.ts
@@ -1,0 +1,483 @@
+import { Component, OnInit, inject, signal, computed } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import { AssessmentService } from './assessment.service';
+import { ClassService } from '../classes/class.service';
+import { StudentService } from '../students/student.service';
+import { AssessmentEventDto, StudentResultDto, StudentDto } from '@app/domain';
+import { AssessmentEventType } from '@app/domain';
+
+interface ResultRow {
+  studentId: string;
+  studentName: string;
+  avatarUrl?: string;
+  grade: number | null;
+  points: number | null;
+  comment: string;
+  dirty: boolean;
+  saving: boolean;
+}
+
+@Component({
+  selector: 'app-assessment-detail',
+  standalone: true,
+  imports: [CommonModule, FormsModule, RouterLink],
+  template: `
+    <div class="page">
+      <header class="page-header">
+        <a class="back-link" routerLink="/app/assessments">← Leistungen</a>
+        @if (event()) {
+          <div class="header-row">
+            <div>
+              <div class="event-type-badge" [attr.data-type]="event()!.type">{{ typeLabel(event()!.type) }}</div>
+              <h1>{{ event()!.title }}</h1>
+              <div class="event-meta">
+                @if (event()!.className) { <span>{{ event()!.className }}</span> }
+                @if (event()!.subjectName) { <span>{{ event()!.subjectName }}</span> }
+                <span>{{ event()!.date | date:'dd.MM.yyyy' }}</span>
+              </div>
+            </div>
+            <div class="header-actions">
+              <button class="btn btn-ghost btn-sm" (click)="toggleStudentPicker()">
+                Schüler zuweisen
+              </button>
+              <button class="btn btn-danger-ghost btn-sm" (click)="deleteEvent()">Löschen</button>
+            </div>
+          </div>
+        }
+      </header>
+
+      <!-- Schüler-Picker -->
+      @if (showStudentPicker() && event()) {
+        <div class="picker-panel">
+          <div class="picker-header">
+            <span class="picker-title">Schüler für dieses Ereignis</span>
+            <button class="btn-icon-sm" (click)="showStudentPicker.set(false)">✕</button>
+          </div>
+          <div class="picker-search">
+            <input type="search" placeholder="Schüler suchen…"
+                   [(ngModel)]="pickerSearch" />
+          </div>
+          <div class="picker-list">
+            @for (s of filteredPickerStudents(); track s.id) {
+              <div class="picker-row" [class.selected]="isAssigned(s.id)" (click)="toggleAssignment(s.id)">
+                <div class="mini-avatar">{{ s.firstName[0] }}{{ s.lastName[0] }}</div>
+                <span class="picker-name">{{ s.lastName }} {{ s.firstName }}</span>
+                @if (isAssigned(s.id)) { <span class="check">✓</span> }
+              </div>
+            }
+          </div>
+          <div class="picker-footer">
+            <span class="picker-count">{{ assignedIds().size }} ausgewählt</span>
+            <button class="btn btn-primary btn-sm" [disabled]="savingAssignment()" (click)="saveAssignment()">
+              {{ savingAssignment() ? 'Wird gespeichert…' : 'Speichern' }}
+            </button>
+          </div>
+        </div>
+      }
+
+      <!-- Ergebnistabelle -->
+      @if (loading()) {
+        <p class="state-msg">Lade Leistungsereignis…</p>
+      } @else if (!event()) {
+        <p class="state-msg">Nicht gefunden.</p>
+      } @else if (rows().length === 0) {
+        <div class="empty-state">
+          <p>Noch keine Schüler zugewiesen.</p>
+          <p class="empty-hint">Klicke auf „Schüler zuweisen" um Schüler hinzuzufügen.</p>
+        </div>
+      } @else {
+        <div class="results-wrap">
+          <!-- Kopfzeile -->
+          <div class="results-header">
+            <span class="col-student">Schüler</span>
+            <span class="col-grade">Note</span>
+            <span class="col-points">Punkte</span>
+            <span class="col-comment">Kommentar</span>
+            <span class="col-action"></span>
+          </div>
+
+          <!-- Zeilen -->
+          @for (row of rows(); track row.studentId) {
+            <div class="result-row" [class.dirty]="row.dirty">
+              <div class="col-student">
+                <div class="mini-avatar">
+                  @if (row.avatarUrl) { <img [src]="row.avatarUrl" [alt]="row.studentName" /> }
+                  @else { {{ row.studentName[0] }} }
+                </div>
+                <a class="student-link" [routerLink]="['/app/students', row.studentId]">
+                  {{ row.studentName }}
+                </a>
+              </div>
+              <div class="col-grade">
+                <select [(ngModel)]="row.grade" (ngModelChange)="markDirty(row)" class="grade-select">
+                  <option [ngValue]="null">—</option>
+                  <option [ngValue]="1">1 – Sehr gut</option>
+                  <option [ngValue]="2">2 – Gut</option>
+                  <option [ngValue]="3">3 – Befriedigend</option>
+                  <option [ngValue]="4">4 – Genügend</option>
+                  <option [ngValue]="5">5 – Nicht genügend</option>
+                </select>
+              </div>
+              <div class="col-points">
+                <input type="number" [(ngModel)]="row.points" (ngModelChange)="markDirty(row)"
+                       placeholder="—" min="0" class="points-input" />
+              </div>
+              <div class="col-comment">
+                <input type="text" [(ngModel)]="row.comment" (ngModelChange)="markDirty(row)"
+                       placeholder="Kommentar…" class="comment-input" />
+              </div>
+              <div class="col-action">
+                @if (row.dirty) {
+                  <button class="save-row-btn" [disabled]="row.saving" (click)="saveRow(row)">
+                    {{ row.saving ? '…' : 'Speichern' }}
+                  </button>
+                } @else {
+                  <span class="saved-indicator">✓</span>
+                }
+              </div>
+            </div>
+          }
+
+          <!-- Alle auf einmal speichern -->
+          @if (hasDirty()) {
+            <div class="bulk-save-bar">
+              <span class="dirty-count">{{ dirtyCount() }} ungespeicherte Änderungen</span>
+              <button class="btn btn-primary" [disabled]="bulkSaving()" (click)="saveAll()">
+                {{ bulkSaving() ? 'Wird gespeichert…' : 'Alle speichern' }}
+              </button>
+            </div>
+          }
+        </div>
+
+        <!-- Zusammenfassung -->
+        <div class="summary">
+          <div class="summary-stat">
+            <span class="s-val">{{ rows().length }}</span>
+            <span class="s-label">Schüler</span>
+          </div>
+          @if (avgGrade() !== null) {
+            <div class="summary-stat">
+              <span class="s-val">{{ avgGrade()!.toFixed(1) }}</span>
+              <span class="s-label">Ø Note</span>
+            </div>
+          }
+          @if (avgPoints() !== null) {
+            <div class="summary-stat">
+              <span class="s-val">{{ avgPoints()!.toFixed(1) }}</span>
+              <span class="s-label">Ø Punkte</span>
+            </div>
+          }
+          <div class="summary-stat">
+            <span class="s-val">{{ gradedCount() }}</span>
+            <span class="s-label">bewertet</span>
+          </div>
+        </div>
+      }
+    </div>
+  `,
+  styles: [`
+    .page { max-width: 900px; margin: 0 auto; padding: var(--sp-6) var(--sp-5); }
+    .back-link { font-size: 13px; color: var(--ink-faint); text-decoration: none; }
+    .back-link:hover { color: var(--ink); }
+    .page-header { margin-bottom: var(--sp-5); }
+    .header-row { display: flex; align-items: flex-start; justify-content: space-between; gap: var(--sp-4); margin-top: var(--sp-3); }
+    .event-type-badge {
+      display: inline-block; font-size: 10px; font-weight: 700; letter-spacing: .8px;
+      text-transform: uppercase; padding: 3px 8px; border-radius: 4px; margin-bottom: var(--sp-2);
+      background: var(--light-teal); color: var(--navy);
+    }
+    .event-type-badge[data-type="EXAM"] { background: #EDD9C4; color: #7A5A3A; }
+    .event-type-badge[data-type="WRITTEN_CHECK"] { background: #E8F4F8; color: #2E7D9A; }
+    h1 { font-family: var(--font-display); font-size: 26px; font-weight: 400; color: var(--navy); margin: 0 0 4px; }
+    .event-meta { display: flex; gap: var(--sp-3); font-size: 13px; color: var(--ink-faint); }
+    .event-meta span::before { content: '·'; margin-right: var(--sp-3); }
+    .event-meta span:first-child::before { content: ''; margin: 0; }
+    .header-actions { display: flex; gap: var(--sp-2); flex-shrink: 0; }
+
+    /* ── Picker ── */
+    .picker-panel {
+      background: var(--white); border: 1px solid var(--border);
+      border-radius: var(--r-lg); margin-bottom: var(--sp-5);
+      box-shadow: var(--sh-md); overflow: hidden;
+    }
+    .picker-header { display: flex; align-items: center; justify-content: space-between; padding: var(--sp-4) var(--sp-5); border-bottom: 1px solid var(--border); }
+    .picker-title { font-size: 13px; font-weight: 600; color: var(--navy); }
+    .btn-icon-sm { background: none; border: none; font-size: 14px; color: var(--ink-faint); cursor: pointer; padding: 4px; }
+    .picker-search { padding: var(--sp-3) var(--sp-5); border-bottom: 1px solid var(--border); }
+    .picker-search input { width: 100%; }
+    .picker-list { max-height: 280px; overflow-y: auto; }
+    .picker-row {
+      display: flex; align-items: center; gap: var(--sp-3);
+      padding: 10px var(--sp-5); cursor: pointer; transition: background .1s;
+    }
+    .picker-row:hover { background: var(--surface); }
+    .picker-row.selected { background: var(--surface); }
+    .picker-name { flex: 1; font-size: 13px; color: var(--ink); }
+    .check { color: var(--navy); font-weight: 700; }
+    .picker-footer { display: flex; align-items: center; justify-content: space-between; padding: var(--sp-4) var(--sp-5); border-top: 1px solid var(--border); background: var(--surface); }
+    .picker-count { font-size: 12px; color: var(--ink-faint); }
+
+    /* ── Results ── */
+    .results-wrap { background: var(--white); border: 1px solid var(--border); border-radius: var(--r-lg); overflow: hidden; margin-bottom: var(--sp-4); }
+    .results-header {
+      display: grid; grid-template-columns: 1fr 130px 100px 1fr 90px;
+      gap: var(--sp-3); padding: 10px var(--sp-5);
+      background: var(--surface); border-bottom: 1px solid var(--border);
+      font-size: 11px; font-weight: 600; text-transform: uppercase;
+      letter-spacing: .8px; color: var(--ink-faint);
+    }
+    .result-row {
+      display: grid; grid-template-columns: 1fr 130px 100px 1fr 90px;
+      gap: var(--sp-3); padding: 10px var(--sp-5);
+      border-bottom: 1px solid var(--border); align-items: center;
+      transition: background .1s;
+    }
+    .result-row:last-of-type { border-bottom: none; }
+    .result-row.dirty { background: #FFFDF5; }
+    .result-row:hover { background: var(--surface); }
+
+    .col-student { display: flex; align-items: center; gap: var(--sp-3); }
+    .mini-avatar {
+      width: 28px; height: 28px; border-radius: 50%; flex-shrink: 0;
+      background: var(--light-teal); color: var(--navy);
+      display: flex; align-items: center; justify-content: center;
+      font-size: 11px; font-weight: 600; overflow: hidden;
+    }
+    .mini-avatar img { width: 100%; height: 100%; object-fit: cover; }
+    .student-link { font-size: 13px; color: var(--navy); text-decoration: none; font-weight: 500; }
+    .student-link:hover { text-decoration: underline; }
+
+    .grade-select { width: 100%; font-size: 13px; }
+    .points-input { width: 100%; font-size: 13px; }
+    .comment-input { width: 100%; font-size: 13px; }
+
+    .save-row-btn {
+      padding: 5px 12px; background: var(--navy); color: var(--white);
+      border: none; border-radius: var(--r-sm); font-size: 12px; font-weight: 500;
+      cursor: pointer; font-family: var(--font-body); white-space: nowrap;
+    }
+    .save-row-btn:disabled { opacity: .4; cursor: not-allowed; }
+    .saved-indicator { font-size: 13px; color: var(--success-fg, #2E7D32); }
+
+    .bulk-save-bar {
+      display: flex; align-items: center; justify-content: space-between;
+      padding: var(--sp-3) var(--sp-5); background: var(--warn-bg, #FFF8E1);
+      border-top: 1px solid var(--border);
+    }
+    .dirty-count { font-size: 13px; color: var(--warn-fg, #F57F17); font-weight: 500; }
+
+    /* ── Summary ── */
+    .summary {
+      display: flex; gap: var(--sp-5);
+      background: var(--white); border: 1px solid var(--border);
+      border-radius: var(--r-lg); padding: var(--sp-4) var(--sp-5);
+    }
+    .summary-stat { display: flex; flex-direction: column; align-items: center; gap: 2px; }
+    .s-val { font-size: 22px; font-weight: 600; color: var(--navy); }
+    .s-label { font-size: 11px; color: var(--ink-faint); text-transform: uppercase; letter-spacing: .6px; }
+
+    /* ── States ── */
+    .state-msg { color: var(--ink-faint); font-size: 14px; }
+    .empty-state { padding: var(--sp-7) var(--sp-5); text-align: center; background: var(--white); border: 1px dashed var(--border); border-radius: var(--r-lg); }
+    .empty-state p { font-size: 14px; color: var(--ink-faint); margin: 0 0 var(--sp-2); }
+    .empty-hint { font-size: 13px !important; }
+
+    /* ── Buttons ── */
+    .btn {
+      display: inline-flex; align-items: center; gap: 6px;
+      padding: 9px 18px; border-radius: var(--r-sm);
+      font-family: var(--font-body); font-size: 13px; font-weight: 500;
+      cursor: pointer; border: none; transition: all .15s; text-decoration: none;
+    }
+    .btn-sm { padding: 6px 14px; font-size: 12px; }
+    .btn-primary { background: var(--navy); color: var(--white); }
+    .btn-primary:disabled { opacity: .45; cursor: not-allowed; }
+    .btn-primary:hover:not(:disabled) { background: #243350; }
+    .btn-ghost { background: transparent; color: var(--ink); border: 1.5px solid var(--border); }
+    .btn-ghost:hover { border-color: var(--navy); }
+    .btn-danger-ghost { background: transparent; color: var(--ink-faint); border: 1.5px solid var(--border); }
+    .btn-danger-ghost:hover { border-color: var(--error-fg); color: var(--error-fg); }
+  `],
+})
+export class AssessmentDetailComponent implements OnInit {
+  private readonly route             = inject(ActivatedRoute);
+  private readonly router            = inject(Router);
+  private readonly assessmentService = inject(AssessmentService);
+  private readonly studentService    = inject(StudentService);
+  private readonly classService      = inject(ClassService);
+
+  event          = signal<AssessmentEventDto | null>(null);
+  loading        = signal(true);
+  showStudentPicker = signal(false);
+  allStudents    = signal<StudentDto[]>([]);
+  pickerSearch   = '';
+  assignedIds    = signal<Set<string>>(new Set());
+  savingAssignment = signal(false);
+  bulkSaving     = signal(false);
+
+  private _rows = signal<ResultRow[]>([]);
+  rows = computed(() => this._rows());
+
+  hasDirty    = computed(() => this._rows().some(r => r.dirty));
+  dirtyCount  = computed(() => this._rows().filter(r => r.dirty).length);
+  gradedCount = computed(() => this._rows().filter(r => r.grade != null || r.points != null).length);
+
+  avgGrade = computed(() => {
+    const grades = this._rows().filter(r => r.grade != null).map(r => r.grade!);
+    return grades.length ? grades.reduce((a, b) => a + b, 0) / grades.length : null;
+  });
+  avgPoints = computed(() => {
+    const pts = this._rows().filter(r => r.points != null).map(r => r.points!);
+    return pts.length ? pts.reduce((a, b) => a + b, 0) / pts.length : null;
+  });
+
+  filteredPickerStudents = computed(() => {
+    const q = this.pickerSearch.toLowerCase().trim();
+    return q
+      ? this.allStudents().filter(s =>
+          (s.firstName + ' ' + s.lastName).toLowerCase().includes(q) ||
+          (s.lastName + ' ' + s.firstName).toLowerCase().includes(q)
+        )
+      : this.allStudents();
+  });
+
+  readonly eventTypes = [
+    { value: AssessmentEventType.ORAL_CHECK,    label: 'Mündliche MÜ' },
+    { value: AssessmentEventType.WRITTEN_CHECK, label: 'Schriftliche MÜ' },
+    { value: AssessmentEventType.EXAM,          label: 'Schularbeit' },
+  ];
+
+  ngOnInit(): void {
+    const id = this.route.snapshot.paramMap.get('id')!;
+    this.studentService.getAll().subscribe(s => this.allStudents.set(s));
+    this.loadEvent(id);
+  }
+
+  loadEvent(id: string): void {
+    this.loading.set(true);
+    this.assessmentService.getOne(id).subscribe({
+      next: (event) => {
+        this.event.set(event);
+        this.assignedIds.set(new Set(event.results.map(r => r.studentId)));
+        this.buildRows(event);
+        this.loading.set(false);
+      },
+      error: () => this.loading.set(false),
+    });
+  }
+
+  buildRows(event: AssessmentEventDto): void {
+    const students = this.allStudents();
+    const rows: ResultRow[] = event.results.map(result => {
+      const student = students.find(s => s.id === result.studentId);
+      return {
+        studentId:   result.studentId,
+        studentName: student ? `${student.lastName} ${student.firstName}` : result.studentId,
+        avatarUrl:   student?.avatarUrl,
+        grade:       result.grade ?? null,
+        points:      result.points ?? null,
+        comment:     result.comment ?? '',
+        dirty:       false,
+        saving:      false,
+      };
+    });
+    rows.sort((a, b) => a.studentName.localeCompare(b.studentName));
+    this._rows.set(rows);
+  }
+
+  markDirty(row: ResultRow): void {
+    this._rows.update(list => list.map(r => r.studentId === row.studentId ? { ...r, dirty: true } : r));
+  }
+
+  saveRow(row: ResultRow): void {
+    this._rows.update(list => list.map(r => r.studentId === row.studentId ? { ...r, saving: true } : r));
+    this.assessmentService.upsertResult(this.event()!.id, {
+      studentId: row.studentId,
+      grade:     row.grade   ?? undefined,
+      points:    row.points  ?? undefined,
+      comment:   row.comment || undefined,
+    }).subscribe({
+      next: () => {
+        this._rows.update(list => list.map(r =>
+          r.studentId === row.studentId ? { ...r, dirty: false, saving: false } : r
+        ));
+      },
+      error: () => {
+        this._rows.update(list => list.map(r =>
+          r.studentId === row.studentId ? { ...r, saving: false } : r
+        ));
+      },
+    });
+  }
+
+  saveAll(): void {
+    this.bulkSaving.set(true);
+    const dirty = this._rows().filter(r => r.dirty);
+    const results = dirty.map(r => ({
+      studentId: r.studentId,
+      grade:     r.grade   ?? undefined,
+      points:    r.points  ?? undefined,
+      comment:   r.comment || undefined,
+    }));
+    this.assessmentService.bulkUpsertResults(this.event()!.id, results).subscribe({
+      next: (updated) => {
+        this._rows.update(list => list.map(r => ({ ...r, dirty: false, saving: false })));
+        this.bulkSaving.set(false);
+      },
+      error: () => this.bulkSaving.set(false),
+    });
+  }
+
+  // ── Schüler-Picker ────────────────────────────────────────────────────────
+
+  toggleStudentPicker(): void {
+    this.showStudentPicker.update(v => !v);
+    if (this.showStudentPicker()) {
+      // Klassenschüler zuerst laden wenn Klasse gesetzt
+      const classId = this.event()?.classId;
+      if (classId) {
+        this.classService.getOne(classId).subscribe(cls => {
+          const classStudents = (cls.students ?? []) as StudentDto[];
+          const others = this.allStudents().filter(s => !classStudents.find(cs => cs.id === s.id));
+          this.allStudents.set([...classStudents, ...others]);
+        });
+      }
+    }
+  }
+
+  isAssigned(studentId: string): boolean {
+    return this.assignedIds().has(studentId);
+  }
+
+  toggleAssignment(studentId: string): void {
+    const set = new Set(this.assignedIds());
+    set.has(studentId) ? set.delete(studentId) : set.add(studentId);
+    this.assignedIds.set(set);
+  }
+
+  saveAssignment(): void {
+    this.savingAssignment.set(true);
+    this.assessmentService.assignStudents(this.event()!.id, [...this.assignedIds()]).subscribe({
+      next: (updated) => {
+        this.event.set(updated);
+        this.buildRows(updated);
+        this.showStudentPicker.set(false);
+        this.savingAssignment.set(false);
+      },
+      error: () => this.savingAssignment.set(false),
+    });
+  }
+
+  typeLabel(type: AssessmentEventType): string {
+    return this.eventTypes.find(t => t.value === type)?.label ?? type;
+  }
+
+  deleteEvent(): void {
+    if (!confirm('Leistungsereignis wirklich löschen? Alle Ergebnisse werden entfernt.')) return;
+    this.assessmentService.delete(this.event()!.id).subscribe({
+      next: () => this.router.navigate(['/app/assessments']),
+    });
+  }
+}

--- a/apps/klara/src/app/features/assessments/assessment-list.component.ts
+++ b/apps/klara/src/app/features/assessments/assessment-list.component.ts
@@ -1,0 +1,315 @@
+import { Component, OnInit, inject, signal, computed } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule, ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
+import { RouterLink } from '@angular/router';
+import { AssessmentService } from './assessment.service';
+import { ClassService } from '../classes/class.service';
+import { SubjectService } from '../classes/reference-data.service';
+import { AssessmentEventDto, ClassDto, SubjectDto } from '@app/domain';
+import { AssessmentEventType } from '@app/domain';
+
+@Component({
+  selector: 'app-assessment-list',
+  standalone: true,
+  imports: [CommonModule, FormsModule, ReactiveFormsModule, RouterLink],
+  template: `
+    <div class="page">
+      <header class="page-header">
+        <div>
+          <h1>Leistungen</h1>
+          <p class="subtitle">Überprüfungen, Schularbeiten und mündliche Mitarbeit</p>
+        </div>
+        <button class="btn btn-primary" (click)="showForm.set(!showForm())">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+          Neu anlegen
+        </button>
+      </header>
+
+      <!-- Anlegen-Formular (inline) -->
+      @if (showForm()) {
+        <div class="create-panel">
+          <h2 class="panel-title">Neues Leistungsereignis</h2>
+          <form [formGroup]="form" (ngSubmit)="create()">
+            <div class="field-row">
+              <div class="field field--grow">
+                <label>Bezeichnung *</label>
+                <input type="text" formControlName="title" placeholder="z.B. Schularbeit Mathematik 1"
+                       [class.invalid]="isInvalid('title')" />
+                @if (isInvalid('title')) { <span class="field-error">Bezeichnung ist erforderlich</span> }
+              </div>
+              <div class="field">
+                <label>Typ *</label>
+                <select formControlName="type">
+                  @for (t of eventTypes; track t.value) {
+                    <option [value]="t.value">{{ t.label }}</option>
+                  }
+                </select>
+              </div>
+              <div class="field">
+                <label>Datum *</label>
+                <input type="date" formControlName="date" [class.invalid]="isInvalid('date')" />
+              </div>
+            </div>
+            <div class="field-row">
+              <div class="field">
+                <label>Klasse</label>
+                <select formControlName="classId">
+                  <option value="">— keine —</option>
+                  @for (cls of classes(); track cls.id) {
+                    <option [value]="cls.id">{{ cls.name }}{{ cls.schoolYear ? ' · ' + cls.schoolYear : '' }}</option>
+                  }
+                </select>
+              </div>
+              <div class="field">
+                <label>Fach</label>
+                <select formControlName="subjectId">
+                  <option value="">— keines —</option>
+                  @for (s of subjects(); track s.id) {
+                    <option [value]="s.id">{{ s.name }}</option>
+                  }
+                </select>
+              </div>
+            </div>
+            @if (serverError()) { <p class="server-error">{{ serverError() }}</p> }
+            <div class="panel-actions">
+              <button type="button" class="btn btn-ghost" (click)="showForm.set(false)">Abbrechen</button>
+              <button type="submit" class="btn btn-primary" [disabled]="saving()">
+                {{ saving() ? 'Wird angelegt…' : 'Anlegen' }}
+              </button>
+            </div>
+          </form>
+        </div>
+      }
+
+      <!-- Filter -->
+      <div class="filter-bar">
+        <select [(ngModel)]="filterClassId" (ngModelChange)="filterClassId = $event">
+          <option value="">Alle Klassen</option>
+          @for (cls of classes(); track cls.id) {
+            <option [value]="cls.id">{{ cls.name }}{{ cls.schoolYear ? ' · ' + cls.schoolYear : '' }}</option>
+          }
+        </select>
+        <select [(ngModel)]="filterSubjectId">
+          <option value="">Alle Fächer</option>
+          @for (s of subjects(); track s.id) {
+            <option [value]="s.id">{{ s.name }}</option>
+          }
+        </select>
+      </div>
+
+      <!-- Liste -->
+      @if (loading()) {
+        <p class="state-msg">Lade Leistungen…</p>
+      } @else if (filtered().length === 0) {
+        <div class="empty-state">
+          <p>Noch keine Leistungsereignisse angelegt.</p>
+          <p class="empty-hint">Klicke auf „Neu anlegen" um die erste Überprüfung zu erfassen.</p>
+        </div>
+      } @else {
+        <div class="event-list">
+          @for (event of filtered(); track event.id) {
+            <a class="event-card" [routerLink]="['/app/assessments', event.id]">
+              <div class="event-main">
+                <div class="event-type-badge" [attr.data-type]="event.type">{{ typeLabel(event.type) }}</div>
+                <div class="event-info">
+                  <span class="event-title">{{ event.title }}</span>
+                  <div class="event-meta">
+                    @if (event.className) { <span>{{ event.className }}</span> }
+                    @if (event.subjectName) { <span>{{ event.subjectName }}</span> }
+                    <span>{{ event.date | date:'dd.MM.yyyy' }}</span>
+                  </div>
+                </div>
+              </div>
+              <div class="event-stats">
+                <span class="stat">{{ event.results.length }}</span>
+                <span class="stat-label">Schüler</span>
+                @if (gradedCount(event) > 0) {
+                  <span class="stat graded">{{ gradedCount(event) }} bewertet</span>
+                }
+              </div>
+              <svg class="chevron" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>
+            </a>
+          }
+        </div>
+      }
+    </div>
+  `,
+  styles: [`
+    .page { max-width: 800px; margin: 0 auto; padding: var(--sp-6) var(--sp-5); }
+    .page-header { display: flex; align-items: flex-start; justify-content: space-between; margin-bottom: var(--sp-5); gap: var(--sp-4); }
+    h1 { font-family: var(--font-display); font-size: 28px; font-weight: 400; color: var(--navy); margin: 0 0 2px; }
+    .subtitle { font-size: 13px; color: var(--ink-faint); margin: 0; }
+
+    /* ── Create Panel ── */
+    .create-panel {
+      background: var(--white); border: 1px solid var(--border);
+      border-radius: var(--r-lg); padding: var(--sp-5);
+      margin-bottom: var(--sp-5);
+      box-shadow: var(--sh-sm);
+    }
+    .panel-title { font-size: 14px; font-weight: 600; color: var(--navy); margin: 0 0 var(--sp-4); }
+    .field-row { display: flex; gap: var(--sp-4); flex-wrap: wrap; margin-bottom: var(--sp-4); }
+    .field { display: flex; flex-direction: column; gap: var(--sp-2); min-width: 140px; }
+    .field--grow { flex: 1; }
+    label { font-size: 12px; font-weight: 500; color: var(--ink-light); }
+    input.invalid, select.invalid { border-color: var(--error-fg); }
+    .field-error { font-size: 11px; color: var(--error-fg); }
+    .server-error { font-size: 13px; color: var(--error-fg); margin-bottom: var(--sp-3); }
+    .panel-actions { display: flex; justify-content: flex-end; gap: var(--sp-3); padding-top: var(--sp-4); border-top: 1px solid var(--border); }
+
+    /* ── Filter ── */
+    .filter-bar {
+      display: flex; gap: var(--sp-3); margin-bottom: var(--sp-4); flex-wrap: wrap;
+    }
+    .filter-bar select { min-width: 160px; }
+
+    /* ── States ── */
+    .state-msg { color: var(--ink-faint); font-size: 14px; }
+    .empty-state {
+      padding: var(--sp-7) var(--sp-5); text-align: center;
+      background: var(--white); border: 1px dashed var(--border); border-radius: var(--r-lg);
+    }
+    .empty-state p { font-size: 14px; color: var(--ink-faint); margin: 0 0 var(--sp-2); }
+    .empty-hint { font-size: 13px !important; }
+
+    /* ── Event List ── */
+    .event-list { display: flex; flex-direction: column; gap: var(--sp-2); }
+    .event-card {
+      display: flex; align-items: center; gap: var(--sp-4);
+      background: var(--white); border: 1px solid var(--border);
+      border-radius: var(--r-md); padding: var(--sp-4) var(--sp-5);
+      text-decoration: none; transition: box-shadow .15s, border-color .15s;
+      cursor: pointer;
+    }
+    .event-card:hover { box-shadow: var(--sh-md); border-color: var(--teal); }
+    .event-main { display: flex; align-items: center; gap: var(--sp-3); flex: 1; }
+    .event-type-badge {
+      font-size: 10px; font-weight: 700; letter-spacing: .8px; text-transform: uppercase;
+      padding: 3px 8px; border-radius: 4px; flex-shrink: 0;
+      background: var(--light-teal); color: var(--navy);
+    }
+    .event-type-badge[data-type="EXAM"] { background: #EDD9C4; color: #7A5A3A; }
+    .event-type-badge[data-type="ORAL_CHECK"] { background: var(--light-teal); color: var(--navy); }
+    .event-type-badge[data-type="WRITTEN_CHECK"] { background: #E8F4F8; color: #2E7D9A; }
+    .event-info { display: flex; flex-direction: column; gap: 2px; }
+    .event-title { font-size: 14px; font-weight: 500; color: var(--navy); }
+    .event-meta { display: flex; gap: var(--sp-3); font-size: 12px; color: var(--ink-faint); }
+    .event-meta span::before { content: '·'; margin-right: var(--sp-3); }
+    .event-meta span:first-child::before { content: ''; margin: 0; }
+    .event-stats { display: flex; align-items: center; gap: var(--sp-2); flex-shrink: 0; }
+    .stat { font-size: 16px; font-weight: 600; color: var(--navy); }
+    .stat-label { font-size: 11px; color: var(--ink-faint); margin-right: var(--sp-2); }
+    .stat.graded { font-size: 12px; font-weight: 500; color: var(--teal); background: var(--light-teal); padding: 2px 8px; border-radius: 10px; }
+    .chevron { color: var(--ink-faint); flex-shrink: 0; }
+
+    /* ── Buttons ── */
+    .btn {
+      display: inline-flex; align-items: center; gap: 6px;
+      padding: 9px 18px; border-radius: var(--r-sm);
+      font-family: var(--font-body); font-size: 13px; font-weight: 500;
+      cursor: pointer; border: none; transition: all .15s; text-decoration: none;
+    }
+    .btn-primary { background: var(--navy); color: var(--white); }
+    .btn-primary:disabled { opacity: .45; cursor: not-allowed; }
+    .btn-primary:hover:not(:disabled) { background: #243350; }
+    .btn-ghost { background: transparent; color: var(--ink); border: 1.5px solid var(--border); }
+    .btn-ghost:hover { border-color: var(--navy); }
+  `],
+})
+export class AssessmentListComponent implements OnInit {
+  private readonly assessmentService = inject(AssessmentService);
+  private readonly classService      = inject(ClassService);
+  private readonly subjectService    = inject(SubjectService);
+  private readonly fb                = inject(FormBuilder);
+
+  events   = signal<AssessmentEventDto[]>([]);
+  classes  = signal<ClassDto[]>([]);
+  subjects = signal<SubjectDto[]>([]);
+  loading  = signal(true);
+  showForm = signal(false);
+  saving   = signal(false);
+  serverError = signal<string | null>(null);
+
+  filterClassId   = '';
+  filterSubjectId = '';
+
+  filtered = computed(() => {
+    let list = this.events();
+    if (this.filterClassId)   list = list.filter(e => e.classId   === this.filterClassId);
+    if (this.filterSubjectId) list = list.filter(e => e.subjectId === this.filterSubjectId);
+    return list;
+  });
+
+  readonly eventTypes = [
+    { value: AssessmentEventType.ORAL_CHECK,    label: 'Mündliche MÜ' },
+    { value: AssessmentEventType.WRITTEN_CHECK, label: 'Schriftliche MÜ' },
+    { value: AssessmentEventType.EXAM,          label: 'Schularbeit' },
+  ];
+
+  form = this.fb.group({
+    title:     ['', [Validators.required, Validators.minLength(1)]],
+    type:      [AssessmentEventType.ORAL_CHECK, Validators.required],
+    date:      [new Date().toISOString().split('T')[0], Validators.required],
+    classId:   [''],
+    subjectId: [''],
+  });
+
+  ngOnInit(): void {
+    this.classService.getAll().subscribe(c => this.classes.set(c));
+    this.subjectService.getAll().subscribe(s => this.subjects.set(s));
+    this.loadEvents();
+  }
+
+  loadEvents(): void {
+    this.loading.set(true);
+    this.assessmentService.getAll().subscribe({
+      next: (events) => {
+        // className und subjectName lokal befüllen
+        const cls = this.classes();
+        const subs = this.subjects();
+        events.forEach(e => {
+          if (!e.className && e.classId)   e.className   = cls.find(c => c.id === e.classId)?.name;
+          if (!e.subjectName && e.subjectId) e.subjectName = subs.find(s => s.id === e.subjectId)?.name;
+        });
+        this.events.set(events);
+        this.loading.set(false);
+      },
+      error: () => this.loading.set(false),
+    });
+  }
+
+  isInvalid(field: string): boolean {
+    const ctrl = this.form.get(field);
+    return !!(ctrl?.invalid && ctrl?.touched);
+  }
+
+  create(): void {
+    if (this.form.invalid) { this.form.markAllAsTouched(); return; }
+    this.saving.set(true);
+    this.serverError.set(null);
+    const v = this.form.getRawValue();
+    this.assessmentService.create({
+      title:     v.title!,
+      type:      v.type as AssessmentEventType,
+      date:      v.date!,
+      classId:   v.classId  || undefined,
+      subjectId: v.subjectId || undefined,
+    }).subscribe({
+      next: (event) => {
+        this.events.update(list => [event, ...list]);
+        this.showForm.set(false);
+        this.form.reset({ type: AssessmentEventType.ORAL_CHECK, date: new Date().toISOString().split('T')[0] });
+        this.saving.set(false);
+      },
+      error: () => { this.serverError.set('Anlegen fehlgeschlagen.'); this.saving.set(false); },
+    });
+  }
+
+  typeLabel(type: AssessmentEventType): string {
+    return this.eventTypes.find(t => t.value === type)?.label ?? type;
+  }
+
+  gradedCount(event: AssessmentEventDto): number {
+    return event.results.filter(r => r.grade != null || r.points != null).length;
+  }
+}

--- a/apps/klara/src/app/features/assessments/assessment.service.ts
+++ b/apps/klara/src/app/features/assessments/assessment.service.ts
@@ -1,0 +1,55 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import {
+  AssessmentEventDto,
+  CreateAssessmentEventDto,
+  UpdateAssessmentEventDto,
+  UpsertStudentResultDto,
+  StudentResultDto,
+} from '@app/domain';
+
+@Injectable({ providedIn: 'root' })
+export class AssessmentService {
+  private readonly http = inject(HttpClient);
+  private readonly base = '/api/assessments';
+
+  getAll(classId?: string, subjectId?: string): Observable<AssessmentEventDto[]> {
+    let params = new HttpParams();
+    if (classId)   params = params.set('classId',   classId);
+    if (subjectId) params = params.set('subjectId', subjectId);
+    return this.http.get<AssessmentEventDto[]>(this.base, { params });
+  }
+
+  getOne(id: string): Observable<AssessmentEventDto> {
+    return this.http.get<AssessmentEventDto>(`${this.base}/${id}`);
+  }
+
+  create(dto: CreateAssessmentEventDto): Observable<AssessmentEventDto> {
+    return this.http.post<AssessmentEventDto>(this.base, dto);
+  }
+
+  update(id: string, dto: UpdateAssessmentEventDto): Observable<AssessmentEventDto> {
+    return this.http.patch<AssessmentEventDto>(`${this.base}/${id}`, dto);
+  }
+
+  delete(id: string): Observable<void> {
+    return this.http.delete<void>(`${this.base}/${id}`);
+  }
+
+  assignStudents(eventId: string, studentIds: string[]): Observable<AssessmentEventDto> {
+    return this.http.put<AssessmentEventDto>(`${this.base}/${eventId}/students`, { studentIds });
+  }
+
+  upsertResult(eventId: string, dto: UpsertStudentResultDto): Observable<StudentResultDto> {
+    return this.http.put<StudentResultDto>(`${this.base}/${eventId}/results/${dto.studentId}`, dto);
+  }
+
+  bulkUpsertResults(eventId: string, results: UpsertStudentResultDto[]): Observable<AssessmentEventDto> {
+    return this.http.put<AssessmentEventDto>(`${this.base}/${eventId}/results`, { results });
+  }
+
+  getResultsForStudent(studentId: string): Observable<StudentResultDto[]> {
+    return this.http.get<StudentResultDto[]>(`${this.base}/student/${studentId}/results`);
+  }
+}

--- a/apps/klara/src/app/features/students/detail/student-detail.component.html
+++ b/apps/klara/src/app/features/students/detail/student-detail.component.html
@@ -214,6 +214,44 @@
         }
       }
 
+
+    <!-- ── Leistungen ──────────────────────────────────────────────── -->
+    <section class="profile-section">
+      <div class="section-header">
+        <div class="section-label">Leistungen</div>
+        <a class="section-link" routerLink="/app/assessments">Alle Leistungen →</a>
+      </div>
+
+      @if (resultsLoading()) {
+        <p class="state-msg-sm">Lade Leistungen…</p>
+      } @else if (results().length === 0) {
+        <p class="state-msg-sm">Noch keine Leistungen erfasst.</p>
+      } @else {
+        <div class="results-list">
+          @for (result of results(); track result.id) {
+            <a class="result-row" [routerLink]="['/app/assessments', result.assessmentEventId]">
+              <div class="result-type-dot" [attr.data-type]="result.assessmentEvent?.type ?? ''"></div>
+              <div class="result-info">
+                <span class="result-title">{{ result.assessmentEvent?.title ?? '—' }}</span>
+                <div class="result-meta">
+                  @if (result.assessmentEvent?.subjectName) { <span>{{ result.assessmentEvent!.subjectName }}</span> }
+                  <span>{{ result.assessmentEvent?.date | date:'dd.MM.yyyy' }}</span>
+                </div>
+              </div>
+              <div class="result-scores">
+                @if (result.grade != null) {
+                  <span class="grade-chip" [attr.data-grade]="result.grade">{{ result.grade }}</span>
+                }
+                @if (result.points != null) {
+                  <span class="points-chip">{{ result.points }} Pkt.</span>
+                }
+              </div>
+            </a>
+          }
+        </div>
+      }
+    </section>
+
     </section>
 
   }

--- a/apps/klara/src/app/features/students/detail/student-detail.component.scss
+++ b/apps/klara/src/app/features/students/detail/student-detail.component.scss
@@ -237,3 +237,43 @@ dd { margin: 0; font-size: 14px; color: var(--ink); }
 .note-select--sm {
   font-size: 12px; padding: 5px 8px; min-width: 120px;
 }
+
+/* ── Leistungen im Profil ─────────────────────────────────────── */
+.section-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: var(--sp-3); }
+.section-link { font-size: 12px; color: var(--teal); text-decoration: none; }
+.section-link:hover { text-decoration: underline; }
+.state-msg-sm { font-size: 13px; color: var(--ink-faint); margin: 0; }
+
+.results-list { display: flex; flex-direction: column; gap: var(--sp-2); }
+.result-row {
+  display: flex; align-items: center; gap: var(--sp-3);
+  padding: var(--sp-3) var(--sp-4);
+  background: var(--surface); border-radius: var(--r-sm);
+  border: 1px solid var(--border); text-decoration: none;
+  transition: border-color .12s;
+}
+.result-row:hover { border-color: var(--teal); }
+.result-type-dot {
+  width: 8px; height: 8px; border-radius: 50%; flex-shrink: 0;
+  background: var(--light-teal);
+}
+.result-type-dot[data-type="EXAM"] { background: #D4B896; }
+.result-type-dot[data-type="WRITTEN_CHECK"] { background: #7BAABA; }
+.result-info { flex: 1; }
+.result-title { font-size: 13px; font-weight: 500; color: var(--navy); display: block; }
+.result-meta { display: flex; gap: var(--sp-3); font-size: 11px; color: var(--ink-faint); margin-top: 2px; }
+.result-meta span::before { content: '·'; margin-right: var(--sp-3); }
+.result-meta span:first-child::before { content: ''; margin: 0; }
+.result-scores { display: flex; align-items: center; gap: var(--sp-2); }
+.grade-chip {
+  width: 24px; height: 24px; border-radius: 50%;
+  background: var(--navy); color: var(--white);
+  display: flex; align-items: center; justify-content: center;
+  font-size: 12px; font-weight: 700;
+}
+.grade-chip[data-grade="1"] { background: #2E7D32; }
+.grade-chip[data-grade="2"] { background: #558B2F; }
+.grade-chip[data-grade="3"] { background: #F57F17; }
+.grade-chip[data-grade="4"] { background: #E65100; }
+.grade-chip[data-grade="5"] { background: #C62828; }
+.points-chip { font-size: 12px; color: var(--ink-faint); }

--- a/apps/klara/src/app/features/students/detail/student-detail.component.ts
+++ b/apps/klara/src/app/features/students/detail/student-detail.component.ts
@@ -4,8 +4,9 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { StudentService } from '../student.service';
 import { NoteService } from '../../notes/note.service';
+import { AssessmentService } from '../../assessments/assessment.service';
 import { SubjectService } from '../../classes/reference-data.service';
-import { StudentDto, NoteDto, CreateNoteDto, UpdateNoteDto, SubjectDto } from '@app/domain';
+import { StudentDto, NoteDto, CreateNoteDto, UpdateNoteDto, SubjectDto, StudentResultDto } from '@app/domain';
 import { NoteType } from '@app/domain';
 
 interface SubjectGroup {
@@ -25,7 +26,8 @@ export class StudentDetailComponent implements OnInit {
   private readonly route          = inject(ActivatedRoute);
   private readonly studentService = inject(StudentService);
   private readonly noteService    = inject(NoteService);
-  private readonly subjectService = inject(SubjectService);
+  private readonly subjectService    = inject(SubjectService);
+  private readonly assessmentService = inject(AssessmentService);
 
   student      = signal<StudentDto | null>(null);
   loading      = signal(true);
@@ -34,6 +36,10 @@ export class StudentDetailComponent implements OnInit {
   notes        = signal<NoteDto[]>([]);
   notesLoading = signal(false);
   saving       = signal(false);
+
+  /** Leistungsergebnisse dieses Schülers */
+  results        = signal<StudentResultDto[]>([]);
+  resultsLoading = signal(false);
 
   /** Alle Fächer der Lehrkraft – aus der API geladen */
   subjects     = signal<SubjectDto[]>([]);
@@ -107,6 +113,21 @@ export class StudentDetailComponent implements OnInit {
       next:  (data) => { this.notes.set(data); this.notesLoading.set(false); },
       error: ()     => { this.notesLoading.set(false); },
     });
+  }
+
+  loadResults(): void {
+    const studentId = this.student()?.id;
+    if (!studentId) return;
+    this.resultsLoading.set(true);
+    this.assessmentService.getResultsForStudent(studentId).subscribe({
+      next:  (data) => { this.results.set(data); this.resultsLoading.set(false); },
+      error: ()     => { this.resultsLoading.set(false); },
+    });
+  }
+
+  gradeLabel(grade: number | undefined): string {
+    const labels: Record<number, string> = { 1: 'Sehr gut', 2: 'Gut', 3: 'Befriedigend', 4: 'Genügend', 5: 'Nicht genügend' };
+    return grade != null ? labels[grade] ?? String(grade) : '—';
   }
 
   toggleNewNoteForm(): void {

--- a/apps/klara/src/app/shell/app-shell.component.ts
+++ b/apps/klara/src/app/shell/app-shell.component.ts
@@ -34,6 +34,14 @@ import { AuthService } from '../auth/auth.service';
             </a>
           </li>
           <li>
+            <a routerLink="/app/assessments" routerLinkActive="active" class="nav-item">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+                <polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/>
+              </svg>
+              Leistungen
+            </a>
+          </li>
+          <li>
             <a routerLink="/app/notes" routerLinkActive="active" class="nav-item">
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
                 <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/>

--- a/apps/server/src/app/assessment/assessment-validation.dto.ts
+++ b/apps/server/src/app/assessment/assessment-validation.dto.ts
@@ -1,0 +1,84 @@
+import { IsArray, Max, Min, IsDateString, IsEnum, IsInt, IsNumber, IsOptional, IsString, IsUUID, MaxLength, MinLength } from 'class-validator';
+import { AssessmentEventType } from '@app/domain';
+
+export class CreateAssessmentEventValidationDto {
+  @IsString()
+  @MinLength(1)
+  @MaxLength(200)
+  title!: string;
+
+  @IsEnum(AssessmentEventType)
+  type!: AssessmentEventType;
+
+  @IsDateString()
+  date!: string;
+
+  @IsOptional()
+  @IsUUID()
+  classId?: string;
+
+  @IsOptional()
+  @IsUUID()
+  subjectId?: string;
+
+  @IsOptional()
+  @IsArray()
+  @IsUUID('4', { each: true })
+  studentIds?: string[];
+}
+
+export class UpdateAssessmentEventValidationDto {
+  @IsOptional()
+  @IsString()
+  @MinLength(1)
+  @MaxLength(200)
+  title?: string;
+
+  @IsOptional()
+  @IsEnum(AssessmentEventType)
+  type?: AssessmentEventType;
+
+  @IsOptional()
+  @IsDateString()
+  date?: string;
+
+  @IsOptional()
+  @IsUUID()
+  classId?: string;
+
+  @IsOptional()
+  @IsUUID()
+  subjectId?: string;
+}
+
+export class UpsertStudentResultValidationDto {
+  @IsUUID()
+  studentId!: string;
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(5)
+  grade?: number;
+
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  points?: number;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(1000)
+  comment?: string;
+}
+
+export class BulkUpsertResultsValidationDto {
+  @IsArray()
+  results!: UpsertStudentResultValidationDto[];
+}
+
+export class AssignStudentsValidationDto {
+  @IsArray()
+  @IsUUID('4', { each: true })
+  studentIds!: string[];
+}

--- a/apps/server/src/app/assessment/assessment.controller.ts
+++ b/apps/server/src/app/assessment/assessment.controller.ts
@@ -1,0 +1,97 @@
+import {
+  Body, Controller, Delete, Get, HttpCode, HttpStatus,
+  Param, Patch, Post, Put, Query, Req, UseGuards,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiTags } from '@nestjs/swagger';
+import { Request } from 'express';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { AssessmentService } from './assessment.service';
+import {
+  CreateAssessmentEventValidationDto,
+  UpdateAssessmentEventValidationDto,
+  UpsertStudentResultValidationDto,
+  BulkUpsertResultsValidationDto,
+  AssignStudentsValidationDto,
+} from './assessment-validation.dto';
+
+@ApiTags('assessments')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
+@Controller('assessments')
+export class AssessmentController {
+  constructor(private readonly service: AssessmentService) {}
+
+  // ── Events ──────────────────────────────────────────────────────────────
+
+  @Get()
+  @ApiOperation({ summary: 'Alle Leistungsereignisse der Lehrkraft' })
+  findAll(
+    @Req() req: Request,
+    @Query('classId') classId?: string,
+    @Query('subjectId') subjectId?: string,
+  ) {
+    return this.service.findAllEvents((req.user as any).id, classId, subjectId);
+  }
+
+  @Get(':id')
+  findOne(@Param('id') id: string, @Req() req: Request) {
+    return this.service.findOneEvent(id, (req.user as any).id);
+  }
+
+  @Post()
+  create(@Body() dto: CreateAssessmentEventValidationDto, @Req() req: Request) {
+    return this.service.createEvent(dto, (req.user as any).id);
+  }
+
+  @Patch(':id')
+  update(@Param('id') id: string, @Body() dto: UpdateAssessmentEventValidationDto, @Req() req: Request) {
+    return this.service.updateEvent(id, dto, (req.user as any).id);
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  remove(@Param('id') id: string, @Req() req: Request) {
+    return this.service.removeEvent(id, (req.user as any).id);
+  }
+
+  // ── Schülerzuweisung ─────────────────────────────────────────────────────
+
+  @Put(':id/students')
+  @ApiOperation({ summary: 'Schüler einem Event zuweisen (ersetzt bestehende Zuweisung)' })
+  assignStudents(
+    @Param('id') id: string,
+    @Body() dto: AssignStudentsValidationDto,
+    @Req() req: Request,
+  ) {
+    return this.service.assignStudents(id, dto.studentIds, (req.user as any).id);
+  }
+
+  // ── Ergebnisse ───────────────────────────────────────────────────────────
+
+  @Put(':id/results/:studentId')
+  @ApiOperation({ summary: 'Ergebnis eines Schülers speichern (upsert)' })
+  upsertResult(
+    @Param('id') eventId: string,
+    @Param('studentId') studentId: string,
+    @Body() dto: UpsertStudentResultValidationDto,
+    @Req() req: Request,
+  ) {
+    return this.service.upsertResult(eventId, { ...dto, studentId }, (req.user as any).id);
+  }
+
+  @Get('student/:studentId/results')
+  @ApiOperation({ summary: 'Alle Ergebnisse eines Schülers' })
+  getStudentResults(@Param('studentId') studentId: string, @Req() req: Request) {
+    return this.service.findResultsForStudent(studentId, (req.user as any).id);
+  }
+
+  @Put(':id/results')
+  @ApiOperation({ summary: 'Ergebnisse für mehrere Schüler auf einmal speichern' })
+  bulkUpsertResults(
+    @Param('id') eventId: string,
+    @Body() dto: BulkUpsertResultsValidationDto,
+    @Req() req: Request,
+  ) {
+    return this.service.bulkUpsertResults(eventId, dto.results, (req.user as any).id);
+  }
+}

--- a/apps/server/src/app/assessment/assessment.module.ts
+++ b/apps/server/src/app/assessment/assessment.module.ts
@@ -2,9 +2,14 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AssessmentEvent } from './assessment-event.entity';
 import { StudentResult } from './student-result.entity';
+import { Student } from '../student/student.entity';
+import { AssessmentService } from './assessment.service';
+import { AssessmentController } from './assessment.controller';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([AssessmentEvent, StudentResult])],
-  exports: [TypeOrmModule],
+  imports: [TypeOrmModule.forFeature([AssessmentEvent, StudentResult, Student])],
+  providers: [AssessmentService],
+  controllers: [AssessmentController],
+  exports: [AssessmentService],
 })
 export class AssessmentModule {}

--- a/apps/server/src/app/assessment/assessment.service.spec.ts
+++ b/apps/server/src/app/assessment/assessment.service.spec.ts
@@ -1,0 +1,213 @@
+import 'reflect-metadata';
+import { Test, TestingModule } from '@nestjs/testing';
+import { getRepositoryToken } from '@nestjs/typeorm';
+import { AssessmentService } from './assessment.service';
+import { AssessmentEvent } from './assessment-event.entity';
+import { StudentResult } from './student-result.entity';
+import { Student } from '../student/student.entity';
+import { AssessmentEventType } from '@app/domain';
+import { NotFoundException } from '@nestjs/common';
+
+const mockEventRepo = () => ({
+  find: jest.fn(),
+  findOne: jest.fn(),
+  create: jest.fn(),
+  save: jest.fn(),
+  remove: jest.fn(),
+});
+const mockResultRepo = () => ({
+  find: jest.fn(),
+  findOne: jest.fn(),
+  create: jest.fn(),
+  save: jest.fn(),
+  remove: jest.fn(),
+});
+const mockStudentRepo = () => ({
+  findBy: jest.fn(),
+});
+
+describe('AssessmentService', () => {
+  let service: AssessmentService;
+  let eventRepo: ReturnType<typeof mockEventRepo>;
+  let resultRepo: ReturnType<typeof mockResultRepo>;
+
+  beforeEach(async () => {
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        AssessmentService,
+        { provide: getRepositoryToken(AssessmentEvent), useFactory: mockEventRepo },
+        { provide: getRepositoryToken(StudentResult),   useFactory: mockResultRepo },
+        { provide: getRepositoryToken(Student),         useFactory: mockStudentRepo },
+      ],
+    }).compile();
+
+    service    = module.get(AssessmentService);
+    eventRepo  = module.get(getRepositoryToken(AssessmentEvent));
+    resultRepo = module.get(getRepositoryToken(StudentResult));
+  });
+
+  const teacherId = 'teacher-uuid';
+  const eventId   = 'event-uuid';
+
+  const mockEvent = {
+    id: eventId,
+    title: 'Test Schularbeit',
+    type: AssessmentEventType.EXAM,
+    date: new Date('2025-03-10'),
+    teacherId,
+    classId: 'class-uuid',
+    subjectId: 'subject-uuid',
+    results: [],
+  };
+
+  describe('findOneEvent', () => {
+    it('should return event with relations', async () => {
+      eventRepo.findOne.mockResolvedValue(mockEvent);
+      const result = await service.findOneEvent(eventId, teacherId);
+      expect(result).toBe(mockEvent);
+      expect(eventRepo.findOne).toHaveBeenCalledWith({
+        where: { id: eventId, teacherId },
+        relations: ['class', 'subject', 'results', 'results.student'],
+      });
+    });
+
+    it('should throw NotFoundException if event not found', async () => {
+      eventRepo.findOne.mockResolvedValue(null);
+      await expect(service.findOneEvent(eventId, teacherId)).rejects.toThrow(NotFoundException);
+    });
+  });
+
+  describe('createEvent', () => {
+    it('should create event without students', async () => {
+      const dto = {
+        title: 'Schularbeit 1',
+        type: AssessmentEventType.EXAM,
+        date: '2025-03-10',
+        classId: 'class-uuid',
+        subjectId: 'subject-uuid',
+      };
+      const created = { id: eventId, ...dto, teacherId, results: [] };
+      eventRepo.create.mockReturnValue(created);
+      eventRepo.save.mockResolvedValue(created);
+      eventRepo.findOne.mockResolvedValue(created);
+
+      const result = await service.createEvent(dto, teacherId);
+      expect(eventRepo.create).toHaveBeenCalled();
+      expect(eventRepo.save).toHaveBeenCalled();
+      expect(result).toBeDefined();
+    });
+
+    it('should create event and assign students', async () => {
+      const dto = {
+        title: 'Schularbeit 2',
+        type: AssessmentEventType.WRITTEN_CHECK,
+        date: '2025-04-01',
+        studentIds: ['s1', 's2', 's3'],
+      };
+      const created = { id: eventId, ...dto, teacherId, results: [] };
+      eventRepo.create.mockReturnValue(created);
+      eventRepo.save.mockResolvedValue(created);
+      eventRepo.findOne.mockResolvedValue(created);
+      resultRepo.create.mockImplementation((d) => d);
+      resultRepo.save.mockResolvedValue([]);
+
+      await service.createEvent(dto, teacherId);
+      // assignStudents wird intern aufgerufen → resultRepo.create 3× aufgerufen
+      expect(resultRepo.create).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe('assignStudents – Massenzuweisung', () => {
+    it('should create results for new students', async () => {
+      eventRepo.findOne.mockResolvedValue({ ...mockEvent, results: [] });
+      resultRepo.create.mockImplementation((d) => d);
+      resultRepo.save.mockResolvedValue([]);
+
+      await service.assignStudents(eventId, ['s1', 's2'], teacherId);
+      expect(resultRepo.create).toHaveBeenCalledTimes(2);
+      expect(resultRepo.save).toHaveBeenCalled();
+    });
+
+    it('should not duplicate existing students', async () => {
+      const existingResult = { studentId: 's1', assessmentEventId: eventId };
+      eventRepo.findOne.mockResolvedValue({ ...mockEvent, results: [existingResult] });
+      resultRepo.create.mockImplementation((d) => d);
+      resultRepo.save.mockResolvedValue([]);
+      resultRepo.remove.mockResolvedValue([]);
+
+      await service.assignStudents(eventId, ['s1', 's2'], teacherId);
+      // Nur s2 ist neu → nur 1 create
+      expect(resultRepo.create).toHaveBeenCalledTimes(1);
+      expect(resultRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ studentId: 's2' })
+      );
+    });
+
+    it('should remove students no longer in list', async () => {
+      const existing = [
+        { studentId: 's1', assessmentEventId: eventId },
+        { studentId: 's2', assessmentEventId: eventId },
+      ];
+      eventRepo.findOne.mockResolvedValue({ ...mockEvent, results: existing });
+      resultRepo.create.mockImplementation((d) => d);
+      resultRepo.save.mockResolvedValue([]);
+      resultRepo.remove.mockResolvedValue([]);
+
+      await service.assignStudents(eventId, ['s1'], teacherId);
+      // s2 soll entfernt werden
+      expect(resultRepo.remove).toHaveBeenCalledWith(
+        expect.arrayContaining([expect.objectContaining({ studentId: 's2' })])
+      );
+    });
+  });
+
+  describe('upsertResult', () => {
+    it('should create a new result if none exists', async () => {
+      eventRepo.findOne.mockResolvedValue(mockEvent);
+      resultRepo.findOne.mockResolvedValue(null);
+      const newResult = { assessmentEventId: eventId, studentId: 's1' };
+      resultRepo.create.mockReturnValue(newResult);
+      resultRepo.save.mockResolvedValue({ ...newResult, grade: 2, points: 40 });
+
+      const result = await service.upsertResult(
+        eventId,
+        { studentId: 's1', grade: 2, points: 40 },
+        teacherId,
+      );
+      expect(resultRepo.create).toHaveBeenCalled();
+      expect(result.grade).toBe(2);
+    });
+
+    it('should update existing result', async () => {
+      eventRepo.findOne.mockResolvedValue(mockEvent);
+      const existing = { assessmentEventId: eventId, studentId: 's1', grade: 3, points: 30 };
+      resultRepo.findOne.mockResolvedValue(existing);
+      resultRepo.save.mockResolvedValue({ ...existing, grade: 1, points: 50 });
+
+      const result = await service.upsertResult(
+        eventId,
+        { studentId: 's1', grade: 1, points: 50 },
+        teacherId,
+      );
+      expect(resultRepo.create).not.toHaveBeenCalled();
+      expect(result.grade).toBe(1);
+    });
+  });
+
+  describe('bulkUpsertResults', () => {
+    it('should call upsertResult for each entry', async () => {
+      eventRepo.findOne.mockResolvedValue({ ...mockEvent, results: [] });
+      resultRepo.findOne.mockResolvedValue(null);
+      resultRepo.create.mockImplementation((d) => d);
+      resultRepo.save.mockImplementation((d) => Promise.resolve({ ...d, grade: d.grade }));
+
+      const results = [
+        { studentId: 's1', grade: 1 },
+        { studentId: 's2', grade: 2 },
+        { studentId: 's3', grade: 3 },
+      ];
+      await service.bulkUpsertResults(eventId, results, teacherId);
+      expect(resultRepo.save).toHaveBeenCalledTimes(3);
+    });
+  });
+});

--- a/apps/server/src/app/assessment/assessment.service.ts
+++ b/apps/server/src/app/assessment/assessment.service.ts
@@ -1,0 +1,162 @@
+import {
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { In, Repository } from 'typeorm';
+import { AssessmentEvent } from './assessment-event.entity';
+import { StudentResult } from './student-result.entity';
+import { Student } from '../student/student.entity';
+import {
+  CreateAssessmentEventDto,
+  UpdateAssessmentEventDto,
+  UpsertStudentResultDto,
+} from '@app/domain';
+
+@Injectable()
+export class AssessmentService {
+  constructor(
+    @InjectRepository(AssessmentEvent)
+    private readonly eventRepo: Repository<AssessmentEvent>,
+    @InjectRepository(StudentResult)
+    private readonly resultRepo: Repository<StudentResult>,
+    @InjectRepository(Student)
+    private readonly studentRepo: Repository<Student>,
+  ) {}
+
+  // ── Events ──────────────────────────────────────────────────────────────
+
+  findAllEvents(teacherId: string, classId?: string, subjectId?: string): Promise<AssessmentEvent[]> {
+    const where: any = { teacherId };
+    if (classId)   where.classId   = classId;
+    if (subjectId) where.subjectId = subjectId;
+    return this.eventRepo.find({
+      where,
+      relations: ['class', 'subject', 'results'],
+      order: { date: 'DESC' },
+    });
+  }
+
+  async findOneEvent(id: string, teacherId: string): Promise<AssessmentEvent> {
+    const event = await this.eventRepo.findOne({
+      where: { id, teacherId },
+      relations: ['class', 'subject', 'results', 'results.student'],
+    });
+    if (!event) throw new NotFoundException('Leistungsereignis nicht gefunden');
+    return event;
+  }
+
+  async createEvent(dto: CreateAssessmentEventDto, teacherId: string): Promise<AssessmentEvent> {
+    const event = this.eventRepo.create({
+      title:     dto.title,
+      type:      dto.type,
+      date:      dto.date as unknown as Date,
+      classId:   dto.classId   ?? null,
+      subjectId: dto.subjectId ?? null,
+      teacherId,
+      results:   [],
+    });
+    const saved = await this.eventRepo.save(event);
+
+    // Schüler direkt bei Erstellung zuweisen
+    if (dto.studentIds?.length) {
+      await this.assignStudents(saved.id, dto.studentIds, teacherId);
+    }
+
+    return this.findOneEvent(saved.id, teacherId);
+  }
+
+  async updateEvent(id: string, dto: UpdateAssessmentEventDto, teacherId: string): Promise<AssessmentEvent> {
+    const event = await this.findOneEvent(id, teacherId);
+    if (dto.title     !== undefined) event.title     = dto.title;
+    if (dto.type      !== undefined) event.type       = dto.type;
+    if (dto.date      !== undefined) event.date       = dto.date as unknown as Date;
+    if (dto.classId   !== undefined) event.classId    = dto.classId   ?? null;
+    if (dto.subjectId !== undefined) event.subjectId  = dto.subjectId ?? null;
+    await this.eventRepo.save(event);
+    return this.findOneEvent(id, teacherId);
+  }
+
+  async removeEvent(id: string, teacherId: string): Promise<void> {
+    const event = await this.findOneEvent(id, teacherId);
+    await this.eventRepo.remove(event);
+  }
+
+  // ── Schülerzuweisung ─────────────────────────────────────────────────────
+
+  async assignStudents(eventId: string, studentIds: string[], teacherId: string): Promise<AssessmentEvent> {
+    const event = await this.findOneEvent(eventId, teacherId);
+
+    // Bestehende Ergebnisse holen – vorhandene Schüler behalten
+    const existingStudentIds = new Set((event.results ?? []).map(r => r.studentId));
+
+    // Neue Schüler hinzufügen (keine doppelten Einträge)
+    const newStudentIds = studentIds.filter(id => !existingStudentIds.has(id));
+    if (newStudentIds.length > 0) {
+      const newResults = newStudentIds.map(studentId =>
+        this.resultRepo.create({ assessmentEventId: eventId, studentId })
+      );
+      await this.resultRepo.save(newResults);
+    }
+
+    // Schüler die nicht mehr in der Liste sind, entfernen
+    const toRemove = (event.results ?? []).filter(r => !studentIds.includes(r.studentId));
+    if (toRemove.length > 0) {
+      await this.resultRepo.remove(toRemove);
+    }
+
+    return this.findOneEvent(eventId, teacherId);
+  }
+
+  // ── Ergebnisse ───────────────────────────────────────────────────────────
+
+  async upsertResult(
+    eventId: string,
+    dto: UpsertStudentResultDto,
+    teacherId: string,
+  ): Promise<StudentResult> {
+    // Sicherstellen dass das Event der Lehrkraft gehört
+    await this.findOneEvent(eventId, teacherId);
+
+    let result = await this.resultRepo.findOne({
+      where: { assessmentEventId: eventId, studentId: dto.studentId },
+    });
+
+    if (!result) {
+      result = this.resultRepo.create({
+        assessmentEventId: eventId,
+        studentId: dto.studentId,
+      });
+    }
+
+    if (dto.grade   !== undefined) result.grade   = dto.grade   ?? null;
+    if (dto.points  !== undefined) result.points  = dto.points  ?? null;
+    if (dto.comment !== undefined) result.comment = dto.comment ?? null;
+
+    return this.resultRepo.save(result);
+  }
+
+  async bulkUpsertResults(
+    eventId: string,
+    results: UpsertStudentResultDto[],
+    teacherId: string,
+  ): Promise<AssessmentEvent> {
+    for (const dto of results) {
+      await this.upsertResult(eventId, dto, teacherId);
+    }
+    return this.findOneEvent(eventId, teacherId);
+  }
+
+  // ── Ergebnisse für einen Schüler ──────────────────────────────────────────
+
+  findResultsForStudent(studentId: string, teacherId: string): Promise<StudentResult[]> {
+    return this.resultRepo.find({
+      where: {
+        studentId,
+        assessmentEvent: { teacherId },
+      },
+      relations: ['assessmentEvent', 'assessmentEvent.subject', 'assessmentEvent.class'],
+      order: { assessmentEvent: { date: 'DESC' } },
+    });
+  }
+}

--- a/libs/domain/src/dtos/assessment.dto.ts
+++ b/libs/domain/src/dtos/assessment.dto.ts
@@ -1,0 +1,68 @@
+import { AssessmentEventType } from '../enums';
+
+// ── StudentResult ────────────────────────────────────────────────────────────
+
+export class AssessmentEventRefDto {
+  id!: string;
+  title!: string;
+  type!: AssessmentEventType;
+  date!: string;
+  subjectName?: string;
+  className?: string;
+}
+
+export class StudentResultDto {
+  id!: string;
+  studentId!: string;
+  assessmentEventId!: string;
+  grade?: number;      // 1–5 österreichisch
+  points?: number;
+  comment?: string;
+  updatedAt!: string;
+  assessmentEvent?: AssessmentEventRefDto;
+}
+
+export class UpsertStudentResultDto {
+  studentId!: string;
+  grade?: number;
+  points?: number;
+  comment?: string;
+}
+
+// ── AssessmentEvent ──────────────────────────────────────────────────────────
+
+export class AssessmentEventDto {
+  id!: string;
+  title!: string;
+  type!: AssessmentEventType;
+  date!: string;
+  teacherId!: string;
+  classId?: string;
+  className?: string;
+  subjectId?: string;
+  subjectName?: string;
+  results!: StudentResultDto[];
+  createdAt!: string;
+}
+
+export class CreateAssessmentEventDto {
+  title!: string;
+  type!: AssessmentEventType;
+  date!: string;
+  classId?: string;
+  subjectId?: string;
+  // Schüler die diesem Event zugewiesen werden
+  studentIds?: string[];
+}
+
+export class UpdateAssessmentEventDto {
+  title?: string;
+  type?: AssessmentEventType;
+  date?: string;
+  classId?: string;
+  subjectId?: string;
+}
+
+export class AssignStudentsDto {
+  studentIds!: string[];
+}

--- a/libs/domain/src/dtos/index.ts
+++ b/libs/domain/src/dtos/index.ts
@@ -4,3 +4,4 @@ export * from './student.dto';
 export * from './class.dto';
 export * from './note.dto';
 // Import DTOs are part of student.dto.ts — already exported via student.dto.ts
+export * from './assessment.dto';


### PR DESCRIPTION
## Backend (Issue 9)
- AssessmentService: vollständiger CRUD für AssessmentEvent
  - Massenzuweisung von Schülern per PUT /api/assessments/:id/students (bestehende Schüler bleiben, neue kommen dazu, entfernte werden gelöscht)
  - Bulk-Upsert Ergebnisse per PUT /api/assessments/:id/results
  - Einzelergebnis per PUT /api/assessments/:id/results/:studentId
  - Ergebnisse eines Schülers per GET /api/assessments/student/:id/results
- AssessmentController: alle Endpunkte JWT-geschützt
- Validation DTOs mit class-validator
- 10 Unit Tests: Massenzuweisung, Dedup, Entfernen, Upsert, Bulk
- Alle Endpunkte in app.module registriert

## Domain DTOs (libs/domain)
- AssessmentEventDto, CreateAssessmentEventDto, UpdateAssessmentEventDto
- StudentResultDto (mit AssessmentEventRefDto für Schülerprofil)
- UpsertStudentResultDto, AssignStudentsDto
- AssessmentEventRefDto für Kontext im Schülerprofil

## Frontend (Issue 10)
- /app/assessments → Übersicht aller Ereignisse mit Filter nach Klasse und Fach; inline Anlegen-Formular
- /app/assessments/:id → Detail mit:
  - Schüler-Picker: Klassenschüler zuerst, Suche, Toggle-Zuweisung
  - Ergebnistabelle: Note (1–5), Punkte, Kommentar inline editierbar
  - Zeilenweises Speichern oder 'Alle speichern' für dirty Zeilen
  - Zusammenfassung: Ø Note, Ø Punkte, Anzahl bewertet
- Schülerprofil: neuer Abschnitt 'Leistungen' mit chronologischer Liste aller Ereignisse, Note als farbiger Kreis (grün→rot nach Note)
- Navigation: Menüpunkt 'Leistungen' in der Sidebar