### PR TITLE
feat: self-hosted fonts via @fontsource – kein Google CDN

### DIFF
--- a/apps/klara/src/index.html
+++ b/apps/klara/src/index.html
@@ -21,10 +21,7 @@
     <link rel="icon" type="image/svg+xml" href="favicon.svg" />
     <link rel="apple-touch-icon" href="apple-touch-icon.png" />
 
-    <!-- Fonts -->
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;1,9..40,300&family=DM+Serif+Display:ital@0;1&display=swap" rel="stylesheet" />
+    <!-- Fonts werden self-hosted via @fontsource (styles.scss) -->
   </head>
   <body>
     <app-root></app-root>

--- a/apps/klara/src/styles.scss
+++ b/apps/klara/src/styles.scss
@@ -1,5 +1,12 @@
 /* ─── Klara – Global Styles ─────────────────────────────────────────────── */
-@import url('https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;1,9..40,300&family=DM+Serif+Display:ital@0;1&display=swap');
+/* ── Fonts – self-hosted via @fontsource (kein Google CDN) ── */
+@import '@fontsource/dm-sans/latin-300.css';
+@import '@fontsource/dm-sans/latin-300-italic.css';
+@import '@fontsource/dm-sans/latin-400.css';
+@import '@fontsource/dm-sans/latin-500.css';
+@import '@fontsource/dm-sans/latin-600.css';
+@import '@fontsource/dm-serif-display/latin-400.css';
+@import '@fontsource/dm-serif-display/latin-400-italic.css';
 
 :root {
   --navy:       #2E3F5C;

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,8 @@
         "@angular/router": "~20.1.0",
         "@angular/ssr": "~20.1.0",
         "@bwip-js/node": "^4.7.0",
+        "@fontsource/dm-sans": "^5.2.8",
+        "@fontsource/dm-serif-display": "^5.2.8",
         "@nestjs/axios": "^4.0.1",
         "@nestjs/common": "^11.0.0",
         "@nestjs/config": "^4.0.2",
@@ -837,6 +839,24 @@
         "webpack-cli": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@angular-devkit/build-angular/node_modules/yaml": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
+      "integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
+      "dev": true,
+      "license": "ISC",
+      "optional": true,
+      "peer": true,
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
       }
     },
     "node_modules/@angular-devkit/build-webpack": {
@@ -4293,6 +4313,24 @@
       "license": "MIT",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@fontsource/dm-sans": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/dm-sans/-/dm-sans-5.2.8.tgz",
+      "integrity": "sha512-tlovG42m9ESG28WiHpLq3F5umAlm64rv0RkqTbYowRn70e9OlRr5a3yTJhrhrY+k5lftR/OFJjPzOLQzk8EfCA==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/dm-serif-display": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/dm-serif-display/-/dm-serif-display-5.2.8.tgz",
+      "integrity": "sha512-GYSDSlGU6vyhv9a5MwaiVNf9HCuSVpK8hEFRyG4NNDHCDeHiX7YHDAcWsaoLKKcfXLgWG9YkBkk9T3SxM4rAjQ==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@gar/promisify": {

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "@angular/router": "~20.1.0",
     "@angular/ssr": "~20.1.0",
     "@bwip-js/node": "^4.7.0",
+    "@fontsource/dm-sans": "^5.2.8",
+    "@fontsource/dm-serif-display": "^5.2.8",
     "@nestjs/axios": "^4.0.1",
     "@nestjs/common": "^11.0.0",
     "@nestjs/config": "^4.0.2",


### PR DESCRIPTION
- @fontsource/dm-sans + @fontsource/dm-serif-display installiert
- styles.scss: Google CDN @import ersetzt durch @fontsource latin-Varianten
- index.html: preconnect + Google Fonts link-Tags entfernt
- 7 woff2-Dateien landen direkt im Angular Build-Bundle
- Kein externer Font-Request → DSGVO-konform ohne Cookie-Einwilligung