### PR TITLE
fix(auth): 401-Logout-Loop unterbinden

### DIFF
--- a/apps/klara/src/app/auth/auth.interceptor.ts
+++ b/apps/klara/src/app/auth/auth.interceptor.ts
@@ -16,12 +16,15 @@ export const authInterceptor: HttpInterceptorFn = (
     ? req.clone({ setHeaders: { Authorization: `Bearer ${token}` } })
     : req;
 
+  // Auth-Endpunkte selbst niemals in den 401-Handler einschließen –
+  // sonst entsteht ein Loop: logout → 401 → logout → 401 → …
+  const isAuthEndpoint = req.url.includes('/api/auth/');
+
   return next(authReq).pipe(
     catchError((err: HttpErrorResponse) => {
-      if (err.status === 401) {
+      if (err.status === 401 && !isAuthEndpoint) {
         // JWT abgelaufen oder ungültig → logout + zurück zur Login-Seite
         authService.logout();
-        router.navigate(['/login']);
       }
       return throwError(() => err);
     }),

--- a/apps/klara/src/app/auth/auth.service.ts
+++ b/apps/klara/src/app/auth/auth.service.ts
@@ -72,14 +72,25 @@ export class AuthService {
     return t === 'cookie' ? null : t;
   }
 
+  private _loggingOut = false;
+
   loginWithGoogle(): void {
     window.location.href = '/api/auth/google';
   }
 
   logout(): void {
+    // Guard: verhindert dass ein 401 auf /api/auth/logout erneut logout() auslöst
+    if (this._loggingOut) return;
+    this._loggingOut = true;
+
     this._clearToken();
-    this.http.get('/api/auth/logout', { withCredentials: true }).subscribe();
-    this.router.navigate(['/login']);
+    // Feuern-und-vergessen – Fehler (z.B. 401 weil Cookie schon weg) ignorieren
+    this.http.get('/api/auth/logout', { withCredentials: true }).subscribe({
+      error: () => { /* absichtlich ignoriert */ },
+    });
+    this.router.navigate(['/login']).then(() => {
+      this._loggingOut = false;
+    });
   }
 
   /** DSGVO Art. 17 – Konto und alle Daten unwiderruflich löschen */


### PR DESCRIPTION
PROBLEM
Der authInterceptor hat bei jedem 401 authService.logout() aufgerufen. logout() macht selbst GET /api/auth/logout – wenn das Cookie bereits ungültig ist, antwortet der Server mit 401 → Interceptor → logout() → /api/auth/logout → 401 → … endlose Schleife von Logout-Requests.

FIX 1 – authInterceptor (auth.interceptor.ts)
- /api/auth/* Endpunkte sind vom 401-Handler ausgenommen (isAuthEndpoint)
- Verhindert dass Logout/Me/Callback selbst den Loop auslösen
- router.navigate(['/login']) aus dem Interceptor entfernt – logout() im AuthService übernimmt das

FIX 2 – AuthService (auth.service.ts)
- _loggingOut Flag: logout() kann nicht zweimal gleichzeitig laufen
- logout() ignoriert Fehler auf /api/auth/logout explizit (Cookie kann bereits weg sein – das ist kein Fehlerfall)
- Flag wird nach navigate().then() zurückgesetzt