### PR TITLE
feat(#53): Stundenplan als Dashboard

### DIFF
--- a/apps/klara/src/app/app.config.ts
+++ b/apps/klara/src/app/app.config.ts
@@ -1,8 +1,11 @@
 import {
   ApplicationConfig,
+  LOCALE_ID,
   provideBrowserGlobalErrorListeners,
   provideZoneChangeDetection,
 } from '@angular/core';
+import { registerLocaleData } from '@angular/common';
+import localeDeAt from '@angular/common/locales/de-AT';
 import { provideRouter } from '@angular/router';
 import { appRoutes } from './app.routes';
 import { provideHttpClient, withFetch, withInterceptors } from '@angular/common/http';
@@ -12,6 +15,8 @@ import {
 } from '@angular/platform-browser';
 import { authInterceptor } from './auth/auth.interceptor';
 
+registerLocaleData(localeDeAt);
+
 export const appConfig: ApplicationConfig = {
   providers: [
     provideClientHydration(withEventReplay()),
@@ -20,5 +25,6 @@ export const appConfig: ApplicationConfig = {
     provideHttpClient(withFetch(), withInterceptors([authInterceptor])),
     provideZoneChangeDetection({ eventCoalescing: true }),
     provideRouter(appRoutes),
+    { provide: LOCALE_ID, useValue: 'de-AT' },
   ],
 };

--- a/apps/klara/src/app/app.routes.ts
+++ b/apps/klara/src/app/app.routes.ts
@@ -1,7 +1,6 @@
 import { Route } from '@angular/router';
 import { authGuard } from './auth/auth.guard';
 import { AppShellComponent } from './shell/app-shell.component';
-import { HomeComponent } from './features/home/home.component';
 import { LoginComponent } from './features/login/login.component';
 import { AuthCallbackComponent } from './features/auth-callback/auth-callback.component';
 
@@ -31,7 +30,18 @@ export const appRoutes: Route[] = [
     component: AppShellComponent,
     canActivate: [authGuard],
     children: [
-      { path: '', component: HomeComponent, title: 'Klara' },
+      // Stundenplan ist das neue Dashboard
+      {
+        path: '',
+        loadComponent: () => import('./features/timetable/timetable.component').then(m => m.TimetableComponent),
+        title: 'Stundenplan – Klara',
+      },
+      // Klassenübersicht (ehemaliges Dashboard) bleibt erhalten
+      {
+        path: 'klassen-uebersicht',
+        loadComponent: () => import('./features/home/home.component').then(m => m.HomeComponent),
+        title: 'Klassenübersicht – Klara',
+      },
       { path: 'assessments',       loadComponent: () => import('./features/assessments/assessment-list.component').then(m => m.AssessmentListComponent),   title: 'Leistungen – Klara' },
       { path: 'assessments/:id',    loadComponent: () => import('./features/assessments/assessment-detail.component').then(m => m.AssessmentDetailComponent), title: 'Leistung – Klara' },
       { path: 'beurteilung',        loadComponent: () => import('./features/beurteilung/beurteilung.component').then(m => m.BeurteilungComponent),            title: 'Beurteilung – Klara' },

--- a/apps/klara/src/app/features/timetable/timetable-entry-form.component.ts
+++ b/apps/klara/src/app/features/timetable/timetable-entry-form.component.ts
@@ -1,0 +1,512 @@
+import {
+  Component, Input, Output, EventEmitter, OnChanges,
+  inject, signal,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule, ReactiveFormsModule, FormBuilder, Validators } from '@angular/forms';
+import { TimetableEntryDto, CreateTimetableEntryDto, UpdateTimetableEntryDto, ClassDto, SubjectDto } from '@app/domain';
+import { RepeatType, WeekVariant } from '@app/domain';
+import { TimetableService } from './timetable.service';
+import { ToastService } from '../../shared/toast/toast.service';
+import {
+  PERIOD_TIMES, DAY_NAMES_LONG, currentSchoolYear,
+} from './week.utils';
+
+const PRESET_COLORS = [
+  '#5B8AC0', // Blau
+  '#5B9E5B', // Grün
+  '#C09040', // Gold
+  '#8070C0', // Lila
+  '#C07070', // Rot
+  '#50A870', // Smaragd
+  '#7BAABA', // Teal
+  '#C0A040', // Ocker
+];
+
+@Component({
+  selector: 'app-timetable-entry-form',
+  standalone: true,
+  imports: [CommonModule, FormsModule, ReactiveFormsModule],
+  template: `
+    <div class="panel-inner">
+
+      <!-- Header -->
+      <div class="panel-header">
+        <div class="panel-header-icon">
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="var(--teal)" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+            <rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/>
+            <line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/>
+          </svg>
+        </div>
+        <h2 class="panel-title">{{ entry ? 'Stunde bearbeiten' : 'Stunde eintragen' }}</h2>
+        <button class="panel-close" (click)="cancelled.emit()" aria-label="Schließen">
+          <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/>
+          </svg>
+        </button>
+      </div>
+
+      <!-- Body -->
+      <div class="panel-body">
+        <form [formGroup]="form" (ngSubmit)="save()">
+
+          <!-- Fach -->
+          <div class="field">
+            <label>Fach *</label>
+            <select formControlName="subjectId" [class.invalid]="isInvalid('subjectId')">
+              <option value="">— Fach wählen —</option>
+              @for (s of subjects; track s.id) {
+                <option [value]="s.id">{{ s.name }}</option>
+              }
+            </select>
+            @if (subjects.length === 0) {
+              <span class="field-hint">Noch keine Fächer. In den Einstellungen anlegen.</span>
+            }
+            @if (isInvalid('subjectId')) {
+              <span class="field-error">Pflichtfeld</span>
+            }
+          </div>
+
+          <!-- Klasse -->
+          <div class="field">
+            <label>Klasse *</label>
+            <select formControlName="classId" [class.invalid]="isInvalid('classId')">
+              <option value="">— Klasse wählen —</option>
+              @for (cls of classes; track cls.id) {
+                <option [value]="cls.id">
+                  {{ cls.name }}{{ cls.schoolYear ? ' · ' + cls.schoolYear : '' }}
+                </option>
+              }
+            </select>
+            @if (isInvalid('classId')) {
+              <span class="field-error">Pflichtfeld</span>
+            }
+          </div>
+
+          <!-- Tag + Stunde -->
+          <div class="field-row">
+            <div class="field">
+              <label>Tag *</label>
+              <select formControlName="dayOfWeek">
+                @for (day of dayOptions; track day.value) {
+                  <option [value]="day.value">{{ day.label }}</option>
+                }
+              </select>
+            </div>
+            <div class="field">
+              <label>Stunde *</label>
+              <select formControlName="period">
+                @for (p of periodOptions; track p.value) {
+                  <option [value]="p.value">{{ p.label }}</option>
+                }
+              </select>
+            </div>
+          </div>
+
+          <!-- Raum -->
+          <div class="field">
+            <label>Raum</label>
+            <input type="text" formControlName="room" placeholder="z.B. Zimmer 12">
+          </div>
+
+          <!-- Wiederholung -->
+          <div class="section-divider">Wiederholung</div>
+
+          <div class="repeat-grid">
+            @for (opt of repeatOptions; track opt.value) {
+              <button
+                type="button"
+                class="repeat-card"
+                [class.active]="form.get('repeatType')!.value === opt.value"
+                (click)="setRepeat(opt.value)">
+                <span class="repeat-icon">{{ opt.icon }}</span>
+                <span class="repeat-label">{{ opt.label }}</span>
+                <span class="repeat-desc">{{ opt.desc }}</span>
+              </button>
+            }
+          </div>
+
+          <!-- A/B-Woche (nur bei BIWEEKLY) -->
+          @if (form.get('repeatType')!.value === RepeatType.BIWEEKLY) {
+            <div class="field" style="margin-top: var(--sp-3)">
+              <label>In welcher Woche?</label>
+              <div class="toggle-row">
+                @for (opt of weekVariantOptions; track opt.value) {
+                  <button
+                    type="button"
+                    class="toggle-btn"
+                    [class.active]="form.get('weekVariant')!.value === opt.value"
+                    (click)="form.get('weekVariant')!.setValue(opt.value)">
+                    {{ opt.label }}
+                  </button>
+                }
+              </div>
+            </div>
+          }
+
+          <!-- Semester (nur bei SEMESTER) -->
+          @if (form.get('repeatType')!.value === RepeatType.SEMESTER) {
+            <div class="field" style="margin-top: var(--sp-3)">
+              <label>Welches Semester?</label>
+              <div class="toggle-row">
+                <button type="button" class="toggle-btn"
+                  [class.active]="form.get('semester')!.value === 1"
+                  (click)="form.get('semester')!.setValue(1)">1. Semester</button>
+                <button type="button" class="toggle-btn"
+                  [class.active]="form.get('semester')!.value === 2"
+                  (click)="form.get('semester')!.setValue(2)">2. Semester</button>
+              </div>
+            </div>
+          }
+
+          <!-- Einmaliges Datum (nur bei ONCE) -->
+          @if (form.get('repeatType')!.value === RepeatType.ONCE) {
+            <div class="field" style="margin-top: var(--sp-3)">
+              <label>Datum *</label>
+              <input type="date" formControlName="onceDate" [class.invalid]="isInvalid('onceDate')">
+              @if (isInvalid('onceDate')) {
+                <span class="field-error">Datum ist Pflicht für einmalige Einträge</span>
+              }
+            </div>
+          }
+
+          <!-- Gültigkeitszeitraum -->
+          <div class="section-divider">
+            <button type="button" class="expand-btn" (click)="showValidity.set(!showValidity())">
+              Gültigkeitszeitraum
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+                   stroke-linecap="round" stroke-linejoin="round"
+                   [style.transform]="showValidity() ? 'rotate(180deg)' : 'rotate(0deg)'"
+                   style="transition: transform .15s">
+                <polyline points="6 9 12 15 18 9"/>
+              </svg>
+            </button>
+          </div>
+
+          @if (showValidity()) {
+            <div class="field-row" style="margin-top: var(--sp-3)">
+              <div class="field">
+                <label>Von</label>
+                <input type="date" formControlName="validFrom">
+              </div>
+              <div class="field">
+                <label>Bis</label>
+                <input type="date" formControlName="validTo">
+              </div>
+            </div>
+            <p class="field-hint" style="margin-top: var(--sp-1)">
+              Leer lassen für das gesamte Schuljahr.
+            </p>
+          }
+
+          <!-- Farbe -->
+          <div class="section-divider">Farbe</div>
+          <div class="color-row">
+            @for (c of presetColors; track c) {
+              <button
+                type="button"
+                class="color-dot"
+                [style.background]="c"
+                [class.selected]="form.get('color')!.value === c"
+                (click)="form.get('color')!.setValue(c)"
+                [title]="c">
+              </button>
+            }
+          </div>
+
+          <!-- Schuljahr (hidden, wird aus parent gesetzt) -->
+          <input type="hidden" formControlName="schoolYear">
+
+        </form>
+      </div>
+
+      <!-- Footer -->
+      <div class="panel-footer">
+        @if (entry) {
+          <button class="btn btn-danger-ghost" (click)="delete()" [disabled]="deleting()">
+            {{ deleting() ? 'Löschen …' : 'Löschen' }}
+          </button>
+        }
+        <div class="footer-actions">
+          <button class="btn btn-ghost" (click)="cancelled.emit()">Abbrechen</button>
+          <button class="btn btn-primary" (click)="save()" [disabled]="saving()">
+            {{ saving() ? 'Speichern …' : 'Speichern' }}
+          </button>
+        </div>
+      </div>
+
+    </div>
+  `,
+  styles: [`
+    .panel-inner { display: flex; flex-direction: column; height: 100%; }
+
+    /* ── Header ── */
+    .panel-header {
+      display: flex; align-items: center; gap: var(--sp-3);
+      padding: var(--sp-5);
+      border-bottom: 1px solid var(--border);
+      flex-shrink: 0;
+    }
+    .panel-header-icon {
+      width: 32px; height: 32px; border-radius: var(--r-sm);
+      background: var(--info-bg);
+      display: flex; align-items: center; justify-content: center;
+      flex-shrink: 0;
+    }
+    .panel-title { font-size: 15px; font-weight: 600; color: var(--navy); flex: 1; margin: 0; }
+    .panel-close {
+      width: 30px; height: 30px; border: none; background: var(--surface);
+      border-radius: var(--r-sm); cursor: pointer; display: flex;
+      align-items: center; justify-content: center;
+      color: var(--ink-light); transition: background .12s;
+    }
+    .panel-close:hover { background: var(--border); }
+
+    /* ── Body ── */
+    .panel-body { flex: 1; overflow-y: auto; padding: var(--sp-5); }
+
+    /* ── Fields ── */
+    .field { margin-bottom: var(--sp-4); }
+    .field label {
+      display: block; font-size: 13px; font-weight: 500;
+      color: var(--ink); margin-bottom: var(--sp-2);
+    }
+    .field-row { display: grid; grid-template-columns: 1fr 1fr; gap: var(--sp-3); }
+    .field-hint { font-size: 12px; color: var(--ink-faint); margin-top: 4px; display: block; }
+    .field-error { font-size: 12px; color: var(--error-fg); margin-top: 4px; display: block; }
+    input.invalid, select.invalid { border-color: var(--error-fg) !important; }
+
+    /* ── Section divider ── */
+    .section-divider {
+      font-size: 11px; font-weight: 600; letter-spacing: 0.8px;
+      text-transform: uppercase; color: var(--ink-faint);
+      display: flex; align-items: center; gap: var(--sp-3);
+      margin: var(--sp-5) 0 var(--sp-3);
+    }
+    .section-divider::before { content: ''; flex: 1; height: 1px; background: var(--border); }
+    .expand-btn {
+      display: flex; align-items: center; gap: var(--sp-2);
+      background: none; border: none; cursor: pointer;
+      font-size: 11px; font-weight: 600; letter-spacing: 0.8px;
+      text-transform: uppercase; color: var(--ink-faint);
+    }
+    .expand-btn:hover { color: var(--ink); }
+
+    /* ── Repeat cards ── */
+    .repeat-grid {
+      display: grid; grid-template-columns: 1fr 1fr;
+      gap: var(--sp-2);
+    }
+    .repeat-card {
+      border: 1.5px solid var(--border); border-radius: var(--r-sm);
+      padding: var(--sp-3); cursor: pointer;
+      background: var(--white); text-align: center;
+      transition: all .12s; display: flex; flex-direction: column;
+      align-items: center; gap: 3px; font-family: var(--font-body);
+    }
+    .repeat-card:hover { border-color: var(--light-teal); background: var(--surface); }
+    .repeat-card.active { border-color: var(--teal); background: #EEF6F9; }
+    .repeat-icon { font-size: 18px; line-height: 1; }
+    .repeat-label { font-size: 12px; font-weight: 600; color: var(--ink); }
+    .repeat-desc { font-size: 11px; color: var(--ink-faint); }
+
+    /* ── Toggle row (A/B, Semester) ── */
+    .toggle-row { display: flex; gap: var(--sp-2); }
+    .toggle-btn {
+      flex: 1; padding: var(--sp-2);
+      border: 1.5px solid var(--border); border-radius: var(--r-sm);
+      background: var(--white); cursor: pointer; font-family: var(--font-body);
+      font-size: 13px; font-weight: 500; color: var(--ink-light);
+      transition: all .12s;
+    }
+    .toggle-btn:hover { border-color: var(--light-teal); }
+    .toggle-btn.active { border-color: var(--teal); background: #EEF6F9; color: var(--navy); }
+
+    /* ── Color dots ── */
+    .color-row { display: flex; gap: var(--sp-2); flex-wrap: wrap; }
+    .color-dot {
+      width: 28px; height: 28px; border-radius: 50%;
+      border: 2.5px solid transparent; cursor: pointer;
+      transition: all .12s; outline: none;
+    }
+    .color-dot:hover { transform: scale(1.15); }
+    .color-dot.selected { border-color: var(--ink); transform: scale(1.15); }
+
+    /* ── Footer ── */
+    .panel-footer {
+      padding: var(--sp-4) var(--sp-5);
+      border-top: 1px solid var(--border);
+      display: flex; align-items: center; justify-content: space-between;
+      flex-shrink: 0; gap: var(--sp-3);
+    }
+    .footer-actions { display: flex; gap: var(--sp-2); margin-left: auto; }
+
+    .btn {
+      display: inline-flex; align-items: center; gap: var(--sp-2);
+      padding: 9px 18px; border-radius: var(--r-sm);
+      font-family: var(--font-body); font-size: 13px; font-weight: 500;
+      cursor: pointer; border: none; transition: all .12s;
+    }
+    .btn:disabled { opacity: 0.55; cursor: not-allowed; }
+    .btn-primary { background: var(--navy); color: var(--white); }
+    .btn-primary:hover:not(:disabled) { background: #243350; box-shadow: var(--sh-md); }
+    .btn-ghost { background: transparent; color: var(--navy); border: 1.5px solid var(--border); }
+    .btn-ghost:hover:not(:disabled) { border-color: var(--navy); background: var(--surface); }
+    .btn-danger-ghost { background: transparent; color: var(--error-fg); border: 1.5px solid transparent; padding-left: var(--sp-2); }
+    .btn-danger-ghost:hover:not(:disabled) { border-color: var(--error-fg); background: var(--error-bg); }
+  `],
+})
+export class TimetableEntryFormComponent implements OnChanges {
+  @Input() entry:       TimetableEntryDto | null = null;
+  @Input() prefillSlot: { day: number; period: number } | null = null;
+  @Input() schoolYear:  string = currentSchoolYear();
+  @Input() classes:     ClassDto[]   = [];
+  @Input() subjects:    SubjectDto[] = [];
+
+  @Output() saved     = new EventEmitter<TimetableEntryDto>();
+  @Output() deleted   = new EventEmitter<string>();
+  @Output() cancelled = new EventEmitter<void>();
+
+  private readonly svc   = inject(TimetableService);
+  private readonly toast = inject(ToastService);
+  private readonly fb    = inject(FormBuilder);
+
+  readonly saving    = signal(false);
+  readonly deleting  = signal(false);
+  readonly showValidity = signal(false);
+
+  readonly RepeatType   = RepeatType;
+  readonly presetColors = PRESET_COLORS;
+
+  readonly dayOptions = Object.entries(DAY_NAMES_LONG).map(([v, l]) => ({
+    value: Number(v), label: l,
+  }));
+
+  readonly periodOptions = Object.entries(PERIOD_TIMES).map(([v, t]) => ({
+    value: Number(v), label: `${v}. Stunde (${t})`,
+  }));
+
+  readonly repeatOptions = [
+    { value: RepeatType.WEEKLY,   icon: '🔁', label: 'Wöchentlich',   desc: 'Jede Woche' },
+    { value: RepeatType.BIWEEKLY, icon: '🔄', label: '2-wöchentlich', desc: 'A/B-Rhythmus' },
+    { value: RepeatType.SEMESTER, icon: '📅', label: 'Halbjährlich',  desc: '1. oder 2. Sem.' },
+    { value: RepeatType.ONCE,     icon: '📌', label: 'Einmalig',      desc: 'Nur dieser Termin' },
+  ];
+
+  readonly weekVariantOptions = [
+    { value: WeekVariant.A,    label: 'Woche A' },
+    { value: WeekVariant.B,    label: 'Woche B' },
+    { value: WeekVariant.BOTH, label: 'Beide' },
+  ];
+
+  readonly form = this.fb.group({
+    subjectId:   ['', Validators.required],
+    classId:     ['', Validators.required],
+    dayOfWeek:   [1],
+    period:      [1],
+    room:        [''],
+    repeatType:  [RepeatType.WEEKLY],
+    weekVariant: [WeekVariant.BOTH],
+    semester:    [1],
+    onceDate:    [''],
+    validFrom:   [''],
+    validTo:     [''],
+    color:       [PRESET_COLORS[0]],
+    schoolYear:  [this.schoolYear],
+  });
+
+  ngOnChanges(): void {
+    if (this.entry) {
+      this.form.patchValue({
+        subjectId:   this.entry.subjectId,
+        classId:     this.entry.classId,
+        dayOfWeek:   this.entry.dayOfWeek,
+        period:      this.entry.period,
+        room:        this.entry.room ?? '',
+        repeatType:  this.entry.repeatType,
+        weekVariant: this.entry.weekVariant ?? WeekVariant.BOTH,
+        semester:    this.entry.semester ?? 1,
+        onceDate:    this.entry.onceDate ?? '',
+        validFrom:   this.entry.validFrom ?? '',
+        validTo:     this.entry.validTo ?? '',
+        color:       this.entry.color ?? PRESET_COLORS[0],
+        schoolYear:  this.schoolYear,
+      });
+      this.showValidity.set(!!(this.entry.validFrom || this.entry.validTo));
+    } else {
+      this.form.reset({
+        dayOfWeek:   this.prefillSlot?.day    ?? 1,
+        period:      this.prefillSlot?.period ?? 1,
+        repeatType:  RepeatType.WEEKLY,
+        weekVariant: WeekVariant.BOTH,
+        semester:    1,
+        color:       PRESET_COLORS[0],
+        schoolYear:  this.schoolYear,
+      });
+      this.showValidity.set(false);
+    }
+  }
+
+  setRepeat(value: RepeatType): void {
+    this.form.get('repeatType')!.setValue(value);
+  }
+
+  isInvalid(field: string): boolean {
+    const ctrl = this.form.get(field);
+    return !!(ctrl?.invalid && ctrl.touched);
+  }
+
+  save(): void {
+    this.form.markAllAsTouched();
+
+    // Extra-Validierung für ONCE
+    if (this.form.get('repeatType')!.value === RepeatType.ONCE
+        && !this.form.get('onceDate')!.value) {
+      return;
+    }
+
+    if (this.form.invalid) return;
+
+    this.saving.set(true);
+    const raw = this.form.value;
+    const dto: CreateTimetableEntryDto = {
+      subjectId:   raw.subjectId!,
+      classId:     raw.classId!,
+      dayOfWeek:   Number(raw.dayOfWeek),
+      period:      Number(raw.period),
+      room:        raw.room || undefined,
+      repeatType:  raw.repeatType as RepeatType,
+      weekVariant: raw.repeatType === RepeatType.BIWEEKLY
+                     ? (raw.weekVariant as WeekVariant)
+                     : undefined,
+      semester:    raw.repeatType === RepeatType.SEMESTER
+                     ? Number(raw.semester)
+                     : undefined,
+      onceDate:    raw.repeatType === RepeatType.ONCE
+                     ? (raw.onceDate || undefined)
+                     : undefined,
+      validFrom:   raw.validFrom || undefined,
+      validTo:     raw.validTo   || undefined,
+      color:       raw.color     || undefined,
+      schoolYear:  this.schoolYear,
+    };
+
+    const req$ = this.entry
+      ? this.svc.update(this.entry.id, dto)
+      : this.svc.create(dto);
+
+    req$.subscribe({
+      next:  e  => { this.saving.set(false); this.saved.emit(e); },
+      error: () => { this.saving.set(false); this.toast.show('error', 'Fehler beim Speichern', 'Bitte versuche es erneut.'); },
+    });
+  }
+
+  delete(): void {
+    if (!this.entry) return;
+    this.deleting.set(true);
+    this.svc.remove(this.entry.id).subscribe({
+      next:  () => { this.deleting.set(false); this.deleted.emit(this.entry!.id); },
+      error: () => { this.deleting.set(false); this.toast.show('error', 'Fehler beim Löschen'); },
+    });
+  }
+}

--- a/apps/klara/src/app/features/timetable/timetable.component.ts
+++ b/apps/klara/src/app/features/timetable/timetable.component.ts
@@ -22,61 +22,117 @@ import {
   template: `
     <div class="tt-page">
 
-      <!-- ── Top Bar ── -->
-      <div class="tt-topbar">
-        <div class="tt-nav-group">
-          <!-- Woche zurück -->
-          <button class="week-nav-btn" (click)="prevWeek()" aria-label="Vorherige Woche">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg>
-          </button>
-          <span class="week-label">{{ weekInfo().label }}</span>
-          <!-- Woche vor -->
-          <button class="week-nav-btn" (click)="nextWeek()" aria-label="Nächste Woche">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>
-          </button>
-          <button class="today-btn" (click)="goToToday()">Heute</button>
-        </div>
-
-        <!-- A/B-Woche Anzeige (nur wenn 2-wöchentliche Einträge vorhanden) -->
-        @if (hasBiweekly()) {
-          <div class="week-type-badge" [class.is-a]="weekInfo().isWeekA" [class.is-b]="!weekInfo().isWeekA">
-            {{ weekInfo().isWeekA ? 'Woche A' : 'Woche B' }}
+      <!-- ══════════════════════════════════════════════════════════════
+           ZUSTAND 1 – ONBOARDING
+           Noch keine Klassen vorhanden → 3-Schritte-Führung
+      ══════════════════════════════════════════════════════════════ -->
+      @if (!loading() && classes().length === 0) {
+        <div class="onboarding-page">
+          <div class="onboarding-greeting">
+            <p class="welcome-label">Willkommen bei klara</p>
+            <h1>Drei Schritte zum ersten Stundenplan</h1>
           </div>
-        }
 
-        <div class="tt-topbar-spacer"></div>
+          <p class="onboarding-intro">
+            Bevor du deinen Stundenplan einrichten kannst, brauchst du Schülerinnen und Schüler,
+            Unterrichtsfächer und mindestens eine Klasse.
+          </p>
 
-        <!-- Schuljahr -->
-        <select class="year-select" [value]="selectedYear()" (change)="onYearChange($event)">
-          @for (y of availableYears; track y) {
-            <option [value]="y">{{ y }}</option>
-          }
-        </select>
+          <div class="onboarding-steps">
 
-        <!-- Neue Stunde -->
-        <button class="btn btn-primary" (click)="openPanel()">
-          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
-          Stunde eintragen
-        </button>
-      </div>
+            <a routerLink="/app/students/new" class="step-card">
+              <div class="step-num">1</div>
+              <div class="step-icon">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+                  <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/><circle cx="9" cy="7" r="4"/>
+                  <path d="M23 21v-2a4 4 0 0 0-3-3.87"/><path d="M16 3.13a4 4 0 0 1 0 7.75"/>
+                </svg>
+              </div>
+              <div class="step-body">
+                <div class="step-title">Schülerinnen und Schüler anlegen</div>
+                <div class="step-desc">Name, Geburtsdatum, Elterninformationen</div>
+              </div>
+              <svg class="step-arrow" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>
+            </a>
 
-      <!-- ── Loading ── -->
-      @if (loading()) {
-        <div class="tt-loading">
-          <div class="skeleton-grid">
-            @for (_ of [1,2,3,4,5,6]; track $index) {
-              <div class="skeleton-card"></div>
-            }
+            <a routerLink="/app/settings" class="step-card">
+              <div class="step-num">2</div>
+              <div class="step-icon">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+                  <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
+                  <polyline points="14 2 14 8 20 8"/><line x1="16" y1="13" x2="8" y2="13"/>
+                </svg>
+              </div>
+              <div class="step-body">
+                <div class="step-title">Unterrichtsfächer anlegen</div>
+                <div class="step-desc">In den Einstellungen: Mathematik, Deutsch, …</div>
+              </div>
+              <svg class="step-arrow" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>
+            </a>
+
+            <a routerLink="/app/classes/new" class="step-card step-card--primary">
+              <div class="step-num step-num--primary">3</div>
+              <div class="step-icon step-icon--primary">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+                  <rect x="3" y="4" width="18" height="18" rx="2"/>
+                  <line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/>
+                  <line x1="3" y1="10" x2="21" y2="10"/>
+                </svg>
+              </div>
+              <div class="step-body">
+                <div class="step-title">Klasse anlegen und Stundenplan einrichten</div>
+                <div class="step-desc">Klasse erstellen, Schüler zuweisen, erste Stunden eintragen</div>
+              </div>
+              <svg class="step-arrow" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>
+            </a>
+
           </div>
         </div>
       }
 
-      <!-- ── Timetable Grid ── -->
-      @else {
+      <!-- ══════════════════════════════════════════════════════════════
+           ZUSTAND 2 + 3 – STUNDENPLAN (leer oder befüllt)
+           Klassen vorhanden → Grid immer sichtbar
+      ══════════════════════════════════════════════════════════════ -->
+      @else if (!loading() && classes().length > 0) {
+
+        <!-- ── Top Bar ── -->
+        <div class="tt-topbar">
+          <div class="tt-nav-group">
+            <button class="week-nav-btn" (click)="prevWeek()" aria-label="Vorherige Woche">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg>
+            </button>
+            <span class="week-label">{{ weekInfo().label }}</span>
+            <button class="week-nav-btn" (click)="nextWeek()" aria-label="Nächste Woche">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>
+            </button>
+            <button class="today-btn" (click)="goToToday()">Heute</button>
+          </div>
+
+          @if (hasBiweekly()) {
+            <div class="week-type-badge" [class.is-a]="weekInfo().isWeekA" [class.is-b]="!weekInfo().isWeekA">
+              {{ weekInfo().isWeekA ? 'Woche A' : 'Woche B' }}
+            </div>
+          }
+
+          <div class="tt-topbar-spacer"></div>
+
+          <select class="year-select" [value]="selectedYear()" (change)="onYearChange($event)">
+            @for (y of availableYears; track y) {
+              <option [value]="y">{{ y }}</option>
+            }
+          </select>
+
+          <button class="btn btn-primary" (click)="openPanel()">
+            <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+            Stunde eintragen
+          </button>
+        </div>
+
+        <!-- ── Grid (immer sichtbar, leer oder befüllt) ── -->
         <div class="tt-wrap">
           <div class="tt-grid">
 
-            <!-- Header: Ecke + Wochentage -->
             <div class="tt-corner"></div>
             @for (day of days; track day) {
               <div class="tt-day-header" [class.tt-today-col]="isDayToday(day)">
@@ -87,15 +143,12 @@ import {
               </div>
             }
 
-            <!-- Stunden-Zeilen -->
             @for (period of periods(); track period) {
-              <!-- Zeit-Spalte -->
               <div class="tt-time">
                 <span class="tt-period-nr">{{ period }}.</span>
                 <span class="tt-period-time">{{ PERIOD_TIMES[period] }}</span>
               </div>
 
-              <!-- Zellen Mo–Fr -->
               @for (day of days; track day) {
                 <div class="tt-cell" [class.tt-today-col]="isDayToday(day)">
                   @if (isDayToday(day)) {
@@ -135,7 +188,6 @@ import {
 
           </div><!-- /tt-grid -->
 
-          <!-- Legende -->
           @if (allEntries().length > 0) {
             <div class="tt-legend">
               <span class="legend-label">Wiederholung:</span>
@@ -147,19 +199,17 @@ import {
           }
 
         </div><!-- /tt-wrap -->
+      }
 
-        <!-- Empty state -->
-        @if (allEntries().length === 0) {
-          <div class="tt-empty">
-            <div class="empty-icon">📅</div>
-            <h2>Noch kein Stundenplan</h2>
-            <p>Trage deine erste Unterrichtsstunde ein, um loszulegen.</p>
-            <button class="btn btn-primary" (click)="openPanel()">
-              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
-              Stunde eintragen
-            </button>
+      <!-- ── Loading ── -->
+      @else if (loading()) {
+        <div class="tt-loading">
+          <div class="skeleton-grid">
+            @for (_ of [1,2,3,4,5,6]; track $index) {
+              <div class="skeleton-card"></div>
+            }
           </div>
-        }
+        </div>
       }
 
     </div><!-- /tt-page -->
@@ -190,7 +240,76 @@ import {
       display: flex; flex-direction: column;
     }
 
-    /* ── Top Bar ── */
+    /* ══════════════════════════════════════
+       ONBOARDING (Zustand 1)
+    ══════════════════════════════════════ */
+    .onboarding-page {
+      max-width: 560px;
+      padding-top: var(--sp-3);
+    }
+
+    .onboarding-greeting { margin-bottom: var(--sp-5); }
+    .welcome-label { font-size: 13px; color: var(--ink-faint); margin-bottom: var(--sp-1); }
+    h1 {
+      font-family: var(--font-display);
+      font-size: 28px; font-weight: 400; color: var(--navy); margin: 0; line-height: 1.2;
+    }
+
+    .onboarding-intro {
+      font-size: 14px; color: var(--ink-faint); line-height: 1.7;
+      margin-bottom: var(--sp-5);
+    }
+
+    .onboarding-steps { display: flex; flex-direction: column; gap: var(--sp-3); }
+
+    .step-card {
+      display: flex; align-items: center; gap: var(--sp-4);
+      padding: var(--sp-4) var(--sp-5);
+      background: var(--white);
+      border: 1.5px solid var(--border);
+      border-radius: var(--r-lg);
+      box-shadow: var(--sh-sm);
+      text-decoration: none; cursor: pointer;
+      transition: box-shadow .15s, transform .15s, border-color .15s;
+    }
+    .step-card:hover {
+      box-shadow: var(--sh-md); transform: translateY(-1px); border-color: var(--teal);
+    }
+    .step-card--primary {
+      border-color: var(--navy); background: var(--navy);
+    }
+    .step-card--primary:hover { background: #243350; border-color: var(--teal); }
+
+    .step-num {
+      width: 24px; height: 24px; border-radius: 50%;
+      background: var(--surface); border: 1.5px solid var(--border);
+      display: flex; align-items: center; justify-content: center;
+      font-size: 11px; font-weight: 700; color: var(--ink-faint); flex-shrink: 0;
+    }
+    .step-num--primary {
+      background: rgba(255,255,255,.15); border-color: rgba(255,255,255,.25); color: rgba(255,255,255,.8);
+    }
+
+    .step-icon {
+      width: 38px; height: 38px; border-radius: var(--r-sm);
+      background: var(--light-teal);
+      display: flex; align-items: center; justify-content: center;
+      flex-shrink: 0; color: var(--navy);
+    }
+    .step-icon--primary { background: rgba(255,255,255,.15); color: var(--white); }
+
+    .step-body { flex: 1; min-width: 0; }
+    .step-title { font-size: 14px; font-weight: 500; color: var(--navy); margin-bottom: 2px; }
+    .step-card--primary .step-title { color: var(--white); }
+    .step-desc { font-size: 12px; color: var(--ink-faint); line-height: 1.5; }
+    .step-card--primary .step-desc { color: rgba(255,255,255,.6); }
+
+    .step-arrow { color: var(--ink-faint); flex-shrink: 0; }
+    .step-card--primary .step-arrow { color: rgba(255,255,255,.5); }
+
+    /* ══════════════════════════════════════
+       TOP BAR (Zustand 2 + 3)
+    ══════════════════════════════════════ */
     .tt-topbar {
       display: flex; align-items: center; gap: var(--sp-3);
       margin-bottom: var(--sp-5); flex-wrap: wrap;
@@ -216,8 +335,7 @@ import {
     .today-btn:hover { border-color: var(--navy); color: var(--navy); }
 
     .week-type-badge {
-      padding: 4px 12px; border-radius: 20px;
-      font-size: 12px; font-weight: 600;
+      padding: 4px 12px; border-radius: 20px; font-size: 12px; font-weight: 600;
     }
     .week-type-badge.is-a { background: var(--light-teal); color: var(--navy); }
     .week-type-badge.is-b { background: #EDD9C4; color: #7A5A3A; }
@@ -228,8 +346,7 @@ import {
       width: auto; min-width: 100px;
       padding: 7px 12px; border-radius: var(--r-sm);
       border: 1.5px solid var(--border); background: var(--white);
-      font-family: var(--font-body); font-size: 13px; color: var(--ink);
-      cursor: pointer;
+      font-family: var(--font-body); font-size: 13px; color: var(--ink); cursor: pointer;
     }
 
     .btn {
@@ -241,21 +358,20 @@ import {
     .btn-primary { background: var(--navy); color: var(--white); }
     .btn-primary:hover { background: #243350; box-shadow: var(--sh-md); }
 
-    /* ── Timetable Wrap ── */
+    /* ══════════════════════════════════════
+       GRID
+    ══════════════════════════════════════ */
     .tt-wrap {
       background: var(--white);
       border-radius: var(--r-lg);
       box-shadow: var(--sh-sm);
-      overflow: hidden;
-      flex: 1;
+      overflow: hidden; flex: 1;
     }
 
-    /* ── Grid ── */
     .tt-grid {
       display: grid;
       grid-template-columns: 56px repeat(5, 1fr);
-      overflow-x: auto;
-      min-width: 600px;
+      overflow-x: auto; min-width: 600px;
     }
 
     .tt-corner {
@@ -264,7 +380,6 @@ import {
       border-bottom: 1px solid var(--border);
     }
 
-    /* Day headers */
     .tt-day-header {
       padding: var(--sp-3) var(--sp-2);
       background: var(--surface);
@@ -273,148 +388,115 @@ import {
       text-align: center;
     }
     .tt-day-header:last-child { border-right: none; }
-    .tt-day-header.tt-today-col { background: rgba(123,170,186,0.07); }
-
+    .tt-day-header.tt-today-col { background: rgba(123,170,186,.07); }
     .tt-day-name {
       font-size: 10px; font-weight: 600; letter-spacing: 0.8px;
       text-transform: uppercase; color: var(--ink-faint);
     }
     .tt-day-date {
-      font-size: 20px; font-weight: 300; color: var(--navy);
-      line-height: 1.3; margin-top: 2px;
+      font-size: 20px; font-weight: 300; color: var(--navy); line-height: 1.3; margin-top: 2px;
     }
-    .tt-day-date.tt-today-date {
-      color: var(--teal); font-weight: 500;
-    }
+    .tt-day-date.tt-today-date { color: var(--teal); font-weight: 500; }
 
-    /* Time column */
     .tt-time {
-      border-right: 1px solid var(--border);
-      border-bottom: 1px solid var(--border);
-      padding: var(--sp-2) var(--sp-2);
-      height: 86px; display: flex; flex-direction: column;
-      align-items: flex-end; justify-content: flex-start;
-      padding-top: var(--sp-2); background: var(--surface);
+      border-right: 1px solid var(--border); border-bottom: 1px solid var(--border);
+      padding: var(--sp-2); height: 86px;
+      display: flex; flex-direction: column; align-items: flex-end;
+      justify-content: flex-start; padding-top: var(--sp-2); background: var(--surface);
     }
-    .tt-period-nr  { font-size: 11px; font-weight: 600; color: var(--ink-faint); }
-    .tt-period-time { font-size: 10px; color: var(--ink-faint); opacity: 0.7; margin-top: 2px; }
+    .tt-period-nr   { font-size: 11px; font-weight: 600; color: var(--ink-faint); }
+    .tt-period-time { font-size: 10px; color: var(--ink-faint); opacity: .7; margin-top: 2px; }
 
-    /* Cells */
     .tt-cell {
-      border-right: 1px solid var(--border);
-      border-bottom: 1px solid var(--border);
-      height: 86px; padding: var(--sp-1);
-      position: relative;
+      border-right: 1px solid var(--border); border-bottom: 1px solid var(--border);
+      height: 86px; padding: var(--sp-1); position: relative;
     }
     .tt-cell:last-child { border-right: none; }
-    .tt-cell.tt-today-col { background: rgba(123,170,186,0.04); }
+    .tt-cell.tt-today-col { background: rgba(123,170,186,.04); }
 
-    /* Today marker line */
     .tt-today-marker {
       position: absolute; top: 0; left: 0; right: 0;
       height: 2px; background: var(--teal);
     }
 
-    /* Lesson block */
     .tt-lesson {
-      border-radius: var(--r-sm);
-      padding: var(--sp-2) var(--sp-2);
+      border-radius: var(--r-sm); padding: var(--sp-2);
       height: calc(100% - 4px); margin: 2px;
-      cursor: pointer;
-      transition: box-shadow .12s, transform .12s;
+      cursor: pointer; transition: box-shadow .12s, transform .12s;
       display: flex; flex-direction: column;
       border-left: 3px solid var(--teal);
       position: relative; overflow: hidden;
     }
     .tt-lesson:hover { box-shadow: var(--sh-md); transform: translateY(-1px); }
-
     .tt-lesson-repeat {
-      font-size: 9px; font-weight: 600; letter-spacing: 0.3px;
-      color: inherit; opacity: 0.6;
-      position: absolute; top: 3px; right: 4px;
+      font-size: 9px; font-weight: 600; color: inherit; opacity: .6;
+      position: absolute; top: 3px; right: 4px; letter-spacing: .3px;
     }
     .tt-lesson-subject { font-size: 12px; font-weight: 600; line-height: 1.3; color: var(--ink); }
     .tt-lesson-class   { font-size: 11px; color: var(--ink-light); margin-top: 1px; }
     .tt-lesson-room    { font-size: 10px; color: var(--ink-faint); margin-top: auto; }
 
-    /* Add button (hover) */
     .tt-add-btn {
       width: 100%; height: 100%;
-      border: 1.5px dashed transparent;
-      border-radius: var(--r-sm);
+      border: 1.5px dashed transparent; border-radius: var(--r-sm);
       background: transparent; cursor: pointer;
       display: flex; align-items: center; justify-content: center;
-      color: var(--ink-faint); transition: all .12s;
-      opacity: 0;
+      color: var(--ink-faint); transition: all .12s; opacity: 0;
     }
     .tt-cell:hover .tt-add-btn {
-      opacity: 1;
-      border-color: var(--light-teal);
-      color: var(--teal);
+      opacity: 1; border-color: var(--light-teal); color: var(--teal);
     }
 
-    /* Legend */
     .tt-legend {
       display: flex; flex-wrap: wrap; align-items: center; gap: var(--sp-2);
       padding: var(--sp-3) var(--sp-5);
-      border-top: 1px solid var(--border);
-      background: var(--surface);
+      border-top: 1px solid var(--border); background: var(--surface);
     }
     .legend-label { font-size: 11px; color: var(--ink-faint); margin-right: var(--sp-1); }
     .legend-chip {
       display: inline-flex; align-items: center;
-      padding: 2px 9px; border-radius: 20px;
-      font-size: 11px; font-weight: 500;
+      padding: 2px 9px; border-radius: 20px; font-size: 11px; font-weight: 500;
     }
     .chip-teal  { background: var(--light-teal); color: var(--navy); }
     .chip-sand  { background: #EDD9C4; color: #7A5A3A; }
     .chip-ghost { background: var(--surface); color: var(--ink-light); border: 1px solid var(--border); }
 
-    /* Loading skeleton */
+    /* ══════════════════════════════════════
+       LOADING
+    ══════════════════════════════════════ */
     .tt-loading { padding: var(--sp-5) 0; }
     .skeleton-grid { display: grid; grid-template-columns: repeat(5, 1fr); gap: var(--sp-3); }
     .skeleton-card {
       height: 80px; border-radius: var(--r-md);
       background: linear-gradient(90deg, var(--surface) 25%, var(--border) 50%, var(--surface) 75%);
-      background-size: 200% 100%;
-      animation: shimmer 1.4s infinite;
+      background-size: 200% 100%; animation: shimmer 1.4s infinite;
     }
     @keyframes shimmer { 0% { background-position: 200% 0; } 100% { background-position: -200% 0; } }
 
-    /* Empty state */
-    .tt-empty {
-      display: flex; flex-direction: column; align-items: center;
-      justify-content: center; padding: var(--sp-8) var(--sp-6);
-      text-align: center; gap: var(--sp-4);
-    }
-    .empty-icon { font-size: 48px; }
-    .tt-empty h2 { font-family: var(--font-display); font-size: 24px; color: var(--navy); font-weight: 400; margin: 0; }
-    .tt-empty p  { font-size: 14px; color: var(--ink-faint); margin: 0; }
-
-    /* ── Overlay ── */
+    /* ══════════════════════════════════════
+       OVERLAY + PANEL
+    ══════════════════════════════════════ */
     .tt-overlay {
-      position: fixed; inset: 0;
-      background: rgba(28,43,58,.35);
-      z-index: 199;
+      position: fixed; inset: 0; background: rgba(28,43,58,.35); z-index: 199;
       animation: fadeIn .2s ease;
     }
     @keyframes fadeIn { from { opacity: 0 } to { opacity: 1 } }
 
-    /* ── Slide-in Panel ── */
     .tt-panel {
       position: fixed; top: 0; right: 0; bottom: 0;
       width: 420px; max-width: 100vw;
-      background: var(--white);
-      box-shadow: var(--sh-lg);
-      z-index: 200;
-      transform: translateX(100%);
-      transition: transform .25s ease;
+      background: var(--white); box-shadow: var(--sh-lg); z-index: 200;
+      transform: translateX(100%); transition: transform .25s ease;
     }
     .tt-panel.open { transform: translateX(0); }
 
-    /* ── Responsive ── */
+    /* ══════════════════════════════════════
+       RESPONSIVE
+    ══════════════════════════════════════ */
     @media (max-width: 768px) {
       .tt-page { padding: var(--sp-4) var(--sp-3); }
+      .onboarding-page { padding-top: 0; }
+      h1 { font-size: 22px; }
       .week-label { min-width: 0; font-size: 13px; }
       .tt-panel { width: 100vw; }
       .tt-grid { min-width: 500px; }
@@ -428,10 +510,10 @@ export class TimetableComponent implements OnInit {
   private readonly subjectSvc   = inject(SubjectService);
 
   // ── State ──────────────────────────────────────────────────────────────
-  readonly loading      = signal(true);
-  readonly allEntries   = signal<TimetableEntryDto[]>([]);
-  readonly classes      = signal<ClassDto[]>([]);
-  readonly subjects     = signal<SubjectDto[]>([]);
+  readonly loading       = signal(true);
+  readonly allEntries    = signal<TimetableEntryDto[]>([]);
+  readonly classes       = signal<ClassDto[]>([]);
+  readonly subjects      = signal<SubjectDto[]>([]);
   readonly currentMonday = signal(getMondayOfWeek());
   readonly selectedYear  = signal(currentSchoolYear());
   readonly panelOpen     = signal(false);
@@ -458,13 +540,16 @@ export class TimetableComponent implements OnInit {
   readonly DAY_NAMES    = DAY_NAMES;
   readonly PERIOD_TIMES = PERIOD_TIMES;
   readonly days         = [1, 2, 3, 4, 5] as const;
-
   readonly availableYears = this.buildYearOptions();
 
   // ── Lifecycle ──────────────────────────────────────────────────────────
   ngOnInit(): void {
-    this.load();
-    this.classSvc.getAll().subscribe(c => this.classes.set(c));
+    // Klassen und Fächer parallel laden – bestimmen welcher Zustand gezeigt wird
+    this.classSvc.getAll().subscribe(c => {
+      this.classes.set(c);
+      // Stundenplan erst laden wenn Klassen bekannt (vermeidet Flicker)
+      this.load();
+    });
     this.subjectSvc.getAll().subscribe(s => this.subjects.set(s));
   }
 

--- a/apps/klara/src/app/features/timetable/timetable.component.ts
+++ b/apps/klara/src/app/features/timetable/timetable.component.ts
@@ -12,7 +12,7 @@ import { SubjectService } from '../classes/reference-data.service';
 import {
   WeekInfo, buildWeekInfo, getMondayOfWeek, dateOfDay, isToday,
   filterEntriesForWeek, repeatLabel, hexToFaint,
-  currentSchoolYear, PERIOD_TIMES, DAY_NAMES,
+  currentSchoolYear, PERIOD_TIMES, DAY_NAMES, DAY_NAMES_LONG,
 } from './week.utils';
 
 @Component({
@@ -109,6 +109,20 @@ import {
             <button class="today-btn" (click)="goToToday()">Heute</button>
           </div>
 
+          <!-- Mobile: Tag-Navigation (nur auf kleinen Screens sichtbar) -->
+          <div class="tt-day-nav">
+            <button class="week-nav-btn" (click)="prevDay()" aria-label="Vorheriger Tag">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg>
+            </button>
+            <span class="tt-day-nav-label">
+              {{ DAY_NAMES_LONG[activeMobileDay()] }},
+              {{ getDayDate(activeMobileDay()) | date:"d. MMM" : undefined : "de-AT" }}
+            </span>
+            <button class="week-nav-btn" (click)="nextDay()" aria-label="Nächster Tag">
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>
+            </button>
+          </div>
+
           @if (hasBiweekly()) {
             <div class="week-type-badge" [class.is-a]="weekInfo().isWeekA" [class.is-b]="!weekInfo().isWeekA">
               {{ weekInfo().isWeekA ? 'Woche A' : 'Woche B' }}
@@ -131,7 +145,9 @@ import {
 
         <!-- ── Grid (immer sichtbar, leer oder befüllt) ── -->
         <div class="tt-wrap">
-          <div class="tt-grid">
+
+          <!-- Desktop: volle Wochenansicht -->
+          <div class="tt-grid tt-grid-desktop">
 
             <div class="tt-corner"></div>
             @for (day of days; track day) {
@@ -186,7 +202,57 @@ import {
               }
             }
 
-          </div><!-- /tt-grid -->
+          </div><!-- /tt-grid-desktop -->
+
+          <!-- Mobile: Tagesansicht (ein Tag auf einmal) -->
+          <div class="tt-grid tt-grid-mobile">
+
+            @for (period of periods(); track period) {
+              <div class="tt-mobile-row" [class.tt-today-row]="isDayToday(activeMobileDay())">
+                <!-- Zeit-Spalte -->
+                <div class="tt-time tt-time-mobile">
+                  <span class="tt-period-nr">{{ period }}.</span>
+                  <span class="tt-period-time">{{ PERIOD_TIMES[period] }}</span>
+                </div>
+
+                <!-- Inhalt -->
+                <div class="tt-cell tt-cell-mobile">
+                  @if (isDayToday(activeMobileDay())) {
+                    <div class="tt-today-marker"></div>
+                  }
+
+                  @for (entry of entriesForSlot(activeMobileDay(), period); track entry.id) {
+                    <div
+                      class="tt-lesson tt-lesson-mobile"
+                      [style.border-left-color]="entry.color ?? '#7BAABA'"
+                      [style.background]="hexToFaint(entry.color)"
+                      (click)="openEdit(entry)"
+                      role="button">
+                      <div class="tt-lesson-mobile-main">
+                        <span class="tt-lesson-subject">{{ entry.subjectName }}</span>
+                        <span class="tt-lesson-class">{{ entry.className }}</span>
+                      </div>
+                      <div class="tt-lesson-mobile-meta">
+                        @if (entry.room) { <span class="tt-lesson-room">{{ entry.room }}</span> }
+                        <span class="tt-lesson-repeat">{{ getRepeatLabel(entry) }}</span>
+                      </div>
+                    </div>
+                  }
+
+                  @if (entriesForSlot(activeMobileDay(), period).length === 0) {
+                    <button
+                      class="tt-add-btn"
+                      (click)="openPanel(activeMobileDay(), period)">
+                      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+                        <line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/>
+                      </svg>
+                    </button>
+                  }
+                </div>
+              </div>
+            }
+
+          </div><!-- /tt-grid-mobile -->
 
           @if (allEntries().length > 0) {
             <div class="tt-legend">
@@ -489,16 +555,102 @@ import {
     .tt-panel.open { transform: translateX(0); }
 
     /* ══════════════════════════════════════
+       TAG-NAVIGATION (Mobile only)
+    ══════════════════════════════════════ */
+    .tt-day-nav {
+      display: none;
+      align-items: center; gap: var(--sp-2);
+    }
+    .tt-day-nav-label {
+      font-size: 14px; font-weight: 500; color: var(--ink);
+      min-width: 160px; text-align: center;
+    }
+
+    /* Desktop: Tagesansicht ausblenden */
+    .tt-grid-mobile { display: none; }
+
+    /* ══════════════════════════════════════
+       MOBILE TAGESANSICHT
+    ══════════════════════════════════════ */
+    .tt-mobile-row {
+      display: grid;
+      grid-template-columns: 52px 1fr;
+      border-bottom: 1px solid var(--border);
+    }
+    .tt-mobile-row:last-child { border-bottom: none; }
+    .tt-mobile-row.tt-today-row { background: rgba(123,170,186,.04); }
+
+    .tt-time-mobile {
+      height: auto; min-height: 72px;
+      padding: var(--sp-3) var(--sp-2);
+      display: flex; flex-direction: column;
+      align-items: flex-end; justify-content: flex-start;
+    }
+
+    .tt-cell-mobile {
+      height: auto; min-height: 72px;
+      padding: var(--sp-2);
+      border-right: none;
+      border-bottom: none;
+    }
+
+    .tt-lesson-mobile {
+      height: auto; min-height: 60px;
+      padding: var(--sp-3);
+      display: flex; align-items: center;
+      justify-content: space-between; gap: var(--sp-3);
+    }
+    .tt-lesson-mobile-main {
+      display: flex; flex-direction: column; gap: 2px; flex: 1;
+    }
+    .tt-lesson-mobile-main .tt-lesson-subject {
+      font-size: 14px;
+    }
+    .tt-lesson-mobile-main .tt-lesson-class {
+      font-size: 12px;
+    }
+    .tt-lesson-mobile-meta {
+      display: flex; flex-direction: column;
+      align-items: flex-end; gap: 2px; flex-shrink: 0;
+    }
+    .tt-lesson-mobile-meta .tt-lesson-room  { font-size: 11px; }
+    .tt-lesson-mobile-meta .tt-lesson-repeat { font-size: 10px; position: static; opacity: .6; }
+
+    /* ══════════════════════════════════════
        RESPONSIVE
     ══════════════════════════════════════ */
     @media (max-width: 768px) {
-      .tt-page { padding: var(--sp-4) var(--sp-3); }
+      .tt-page { padding: var(--sp-3) var(--sp-3); }
       .onboarding-page { padding-top: 0; }
       h1 { font-size: 22px; }
-      .week-label { min-width: 0; font-size: 13px; }
+
+      /* Topbar: Wochennavigation kompakter */
+      .tt-topbar { gap: var(--sp-2); }
+      .week-label { min-width: 0; font-size: 12px; padding: 0 var(--sp-2); }
+      .tt-topbar-spacer { display: none; }
+      .year-select { display: none; }
+
+      /* Tag-Navigation einblenden */
+      .tt-day-nav { display: flex; }
+
+      /* Desktop-Grid ausblenden, Mobile-Grid einblenden */
+      .tt-grid-desktop { display: none; }
+      .tt-grid-mobile  { display: block; }
+
+      /* Panel Vollbild */
       .tt-panel { width: 100vw; }
-      .tt-grid { min-width: 500px; }
-      .tt-day-date { font-size: 16px; }
+
+      /* Wochentage-Topbar Knöpfe kleiner */
+      .week-nav-btn { width: 26px; height: 26px; }
+      .today-btn { padding: 4px 10px; font-size: 11px; }
+      .btn { padding: 7px 12px; font-size: 12px; }
+
+      /* Legende kompakter */
+      .tt-legend { padding: var(--sp-2) var(--sp-3); gap: var(--sp-1); }
+
+      /* Onboarding */
+      .step-card { padding: var(--sp-3) var(--sp-4); }
+      .step-icon { width: 32px; height: 32px; }
     }
   `],
 })
@@ -514,9 +666,10 @@ export class TimetableComponent implements OnInit {
   readonly subjects      = signal<SubjectDto[]>([]);
   readonly currentMonday = signal(getMondayOfWeek());
   readonly selectedYear  = signal(currentSchoolYear());
-  readonly panelOpen     = signal(false);
-  readonly editEntry     = signal<TimetableEntryDto | null>(null);
-  readonly prefillSlot   = signal<{ day: number; period: number } | null>(null);
+  readonly panelOpen      = signal(false);
+  readonly editEntry      = signal<TimetableEntryDto | null>(null);
+  readonly prefillSlot    = signal<{ day: number; period: number } | null>(null);
+  readonly activeMobileDay = signal<number>(this.todayDayOfWeek());
 
   // ── Computed ───────────────────────────────────────────────────────────
   readonly weekInfo = computed<WeekInfo>(() => buildWeekInfo(this.currentMonday()));
@@ -535,9 +688,10 @@ export class TimetableComponent implements OnInit {
   );
 
   // ── Constants ──────────────────────────────────────────────────────────
-  readonly DAY_NAMES    = DAY_NAMES;
-  readonly PERIOD_TIMES = PERIOD_TIMES;
-  readonly days         = [1, 2, 3, 4, 5] as const;
+  readonly DAY_NAMES      = DAY_NAMES;
+  readonly DAY_NAMES_LONG = DAY_NAMES_LONG;
+  readonly PERIOD_TIMES   = PERIOD_TIMES;
+  readonly days           = [1, 2, 3, 4, 5] as const;
   readonly availableYears = this.buildYearOptions();
 
   // ── Lifecycle ──────────────────────────────────────────────────────────
@@ -562,7 +716,39 @@ export class TimetableComponent implements OnInit {
   // ── Week navigation ────────────────────────────────────────────────────
   prevWeek(): void { this.currentMonday.update(d => addDays(d, -7)); }
   nextWeek(): void { this.currentMonday.update(d => addDays(d,  7)); }
-  goToToday(): void { this.currentMonday.set(getMondayOfWeek()); }
+  goToToday(): void {
+    this.currentMonday.set(getMondayOfWeek());
+    this.activeMobileDay.set(this.todayDayOfWeek());
+  }
+
+  prevDay(): void {
+    const current = this.activeMobileDay();
+    if (current > 1) {
+      this.activeMobileDay.set(current - 1);
+    } else {
+      // Montag → springe zur Vorwoche Freitag
+      this.prevWeek();
+      this.activeMobileDay.set(5);
+    }
+  }
+
+  nextDay(): void {
+    const current = this.activeMobileDay();
+    if (current < 5) {
+      this.activeMobileDay.set(current + 1);
+    } else {
+      // Freitag → springe zur nächsten Woche Montag
+      this.nextWeek();
+      this.activeMobileDay.set(1);
+    }
+  }
+
+  private todayDayOfWeek(): number {
+    const day = new Date().getDay(); // 0=So, 1=Mo...
+    // Wenn Wochenende → zeige Montag
+    if (day === 0 || day === 6) return 1;
+    return day;
+  }
 
   onYearChange(event: Event): void {
     this.selectedYear.set((event.target as HTMLSelectElement).value);

--- a/apps/klara/src/app/features/timetable/timetable.component.ts
+++ b/apps/klara/src/app/features/timetable/timetable.component.ts
@@ -1,0 +1,557 @@
+import {
+  Component, OnInit, inject, signal, computed,
+} from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { RouterLink } from '@angular/router';
+import { TimetableEntryDto, ClassDto, SubjectDto } from '@app/domain';
+import { RepeatType } from '@app/domain';
+import { TimetableService } from './timetable.service';
+import { TimetableEntryFormComponent } from './timetable-entry-form.component';
+import { ClassService } from '../classes/class.service';
+import { SubjectService } from '../classes/reference-data.service';
+import {
+  WeekInfo, buildWeekInfo, getMondayOfWeek, dateOfDay, isToday,
+  filterEntriesForWeek, repeatLabel, hexToFaint,
+  currentSchoolYear, PERIOD_TIMES, DAY_NAMES,
+} from './week.utils';
+
+@Component({
+  selector: 'app-timetable',
+  standalone: true,
+  imports: [CommonModule, RouterLink, TimetableEntryFormComponent],
+  template: `
+    <div class="tt-page">
+
+      <!-- ── Top Bar ── -->
+      <div class="tt-topbar">
+        <div class="tt-nav-group">
+          <!-- Woche zurück -->
+          <button class="week-nav-btn" (click)="prevWeek()" aria-label="Vorherige Woche">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg>
+          </button>
+          <span class="week-label">{{ weekInfo().label }}</span>
+          <!-- Woche vor -->
+          <button class="week-nav-btn" (click)="nextWeek()" aria-label="Nächste Woche">
+            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 18 15 12 9 6"/></svg>
+          </button>
+          <button class="today-btn" (click)="goToToday()">Heute</button>
+        </div>
+
+        <!-- A/B-Woche Anzeige (nur wenn 2-wöchentliche Einträge vorhanden) -->
+        @if (hasBiweekly()) {
+          <div class="week-type-badge" [class.is-a]="weekInfo().isWeekA" [class.is-b]="!weekInfo().isWeekA">
+            {{ weekInfo().isWeekA ? 'Woche A' : 'Woche B' }}
+          </div>
+        }
+
+        <div class="tt-topbar-spacer"></div>
+
+        <!-- Schuljahr -->
+        <select class="year-select" [value]="selectedYear()" (change)="onYearChange($event)">
+          @for (y of availableYears; track y) {
+            <option [value]="y">{{ y }}</option>
+          }
+        </select>
+
+        <!-- Neue Stunde -->
+        <button class="btn btn-primary" (click)="openPanel()">
+          <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+          Stunde eintragen
+        </button>
+      </div>
+
+      <!-- ── Loading ── -->
+      @if (loading()) {
+        <div class="tt-loading">
+          <div class="skeleton-grid">
+            @for (_ of [1,2,3,4,5,6]; track $index) {
+              <div class="skeleton-card"></div>
+            }
+          </div>
+        </div>
+      }
+
+      <!-- ── Timetable Grid ── -->
+      @else {
+        <div class="tt-wrap">
+          <div class="tt-grid">
+
+            <!-- Header: Ecke + Wochentage -->
+            <div class="tt-corner"></div>
+            @for (day of days; track day) {
+              <div class="tt-day-header" [class.tt-today-col]="isDayToday(day)">
+                <div class="tt-day-name">{{ DAY_NAMES[day] }}</div>
+                <div class="tt-day-date" [class.tt-today-date]="isDayToday(day)">
+                  {{ getDayDate(day) | date:'d' }}
+                </div>
+              </div>
+            }
+
+            <!-- Stunden-Zeilen -->
+            @for (period of periods(); track period) {
+              <!-- Zeit-Spalte -->
+              <div class="tt-time">
+                <span class="tt-period-nr">{{ period }}.</span>
+                <span class="tt-period-time">{{ PERIOD_TIMES[period] }}</span>
+              </div>
+
+              <!-- Zellen Mo–Fr -->
+              @for (day of days; track day) {
+                <div class="tt-cell" [class.tt-today-col]="isDayToday(day)">
+                  @if (isDayToday(day)) {
+                    <div class="tt-today-marker"></div>
+                  }
+
+                  @for (entry of entriesForSlot(day, period); track entry.id) {
+                    <div
+                      class="tt-lesson"
+                      [style.border-left-color]="entry.color ?? '#7BAABA'"
+                      [style.background]="hexToFaint(entry.color)"
+                      (click)="openEdit(entry)"
+                      role="button"
+                      [attr.aria-label]="entry.subjectName + ', ' + entry.className">
+                      <span class="tt-lesson-repeat">{{ getRepeatLabel(entry) }}</span>
+                      <span class="tt-lesson-subject">{{ entry.subjectName }}</span>
+                      <span class="tt-lesson-class">{{ entry.className }}</span>
+                      @if (entry.room) {
+                        <span class="tt-lesson-room">{{ entry.room }}</span>
+                      }
+                    </div>
+                  }
+
+                  @if (entriesForSlot(day, period).length === 0) {
+                    <button
+                      class="tt-add-btn"
+                      (click)="openPanel(day, period)"
+                      [attr.aria-label]="'Stunde eintragen ' + DAY_NAMES[day] + ' ' + period">
+                      <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+                        <line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/>
+                      </svg>
+                    </button>
+                  }
+                </div>
+              }
+            }
+
+          </div><!-- /tt-grid -->
+
+          <!-- Legende -->
+          @if (allEntries().length > 0) {
+            <div class="tt-legend">
+              <span class="legend-label">Wiederholung:</span>
+              <span class="legend-chip chip-teal">wöchentl.</span>
+              <span class="legend-chip chip-teal">2-wöchentl.</span>
+              <span class="legend-chip chip-sand">1./2. Sem.</span>
+              <span class="legend-chip chip-ghost">einmalig</span>
+            </div>
+          }
+
+        </div><!-- /tt-wrap -->
+
+        <!-- Empty state -->
+        @if (allEntries().length === 0) {
+          <div class="tt-empty">
+            <div class="empty-icon">📅</div>
+            <h2>Noch kein Stundenplan</h2>
+            <p>Trage deine erste Unterrichtsstunde ein, um loszulegen.</p>
+            <button class="btn btn-primary" (click)="openPanel()">
+              <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+              Stunde eintragen
+            </button>
+          </div>
+        }
+      }
+
+    </div><!-- /tt-page -->
+
+    <!-- ── Overlay ── -->
+    @if (panelOpen()) {
+      <div class="tt-overlay" (click)="closePanel()"></div>
+    }
+
+    <!-- ── Slide-in Panel ── -->
+    <div class="tt-panel" [class.open]="panelOpen()">
+      <app-timetable-entry-form
+        [entry]="editEntry()"
+        [prefillSlot]="prefillSlot()"
+        [schoolYear]="selectedYear()"
+        [classes]="classes()"
+        [subjects]="subjects()"
+        (saved)="onSaved($event)"
+        (deleted)="onDeleted($event)"
+        (cancelled)="closePanel()"
+      />
+    </div>
+  `,
+  styles: [`
+    .tt-page {
+      padding: var(--sp-5) var(--sp-6);
+      min-height: calc(100vh - 0px);
+      display: flex; flex-direction: column;
+    }
+
+    /* ── Top Bar ── */
+    .tt-topbar {
+      display: flex; align-items: center; gap: var(--sp-3);
+      margin-bottom: var(--sp-5); flex-wrap: wrap;
+    }
+    .tt-nav-group { display: flex; align-items: center; gap: var(--sp-2); }
+    .week-nav-btn {
+      width: 30px; height: 30px; border-radius: var(--r-sm);
+      border: 1.5px solid var(--border); background: var(--white);
+      cursor: pointer; display: flex; align-items: center; justify-content: center;
+      color: var(--ink-light); transition: all .12s;
+    }
+    .week-nav-btn:hover { border-color: var(--teal); color: var(--teal); }
+    .week-label {
+      font-size: 14px; font-weight: 500; color: var(--ink);
+      padding: 0 var(--sp-3); min-width: 200px; text-align: center;
+    }
+    .today-btn {
+      padding: 5px 12px; border-radius: var(--r-sm);
+      border: 1.5px solid var(--border); background: var(--white);
+      font-family: var(--font-body); font-size: 12px; font-weight: 500;
+      color: var(--ink-light); cursor: pointer; transition: all .12s;
+    }
+    .today-btn:hover { border-color: var(--navy); color: var(--navy); }
+
+    .week-type-badge {
+      padding: 4px 12px; border-radius: 20px;
+      font-size: 12px; font-weight: 600;
+    }
+    .week-type-badge.is-a { background: var(--light-teal); color: var(--navy); }
+    .week-type-badge.is-b { background: #EDD9C4; color: #7A5A3A; }
+
+    .tt-topbar-spacer { flex: 1; }
+
+    .year-select {
+      width: auto; min-width: 100px;
+      padding: 7px 12px; border-radius: var(--r-sm);
+      border: 1.5px solid var(--border); background: var(--white);
+      font-family: var(--font-body); font-size: 13px; color: var(--ink);
+      cursor: pointer;
+    }
+
+    .btn {
+      display: inline-flex; align-items: center; gap: var(--sp-2);
+      padding: 9px 16px; border-radius: var(--r-sm);
+      font-family: var(--font-body); font-size: 13px; font-weight: 500;
+      cursor: pointer; border: none; transition: all .12s;
+    }
+    .btn-primary { background: var(--navy); color: var(--white); }
+    .btn-primary:hover { background: #243350; box-shadow: var(--sh-md); }
+
+    /* ── Timetable Wrap ── */
+    .tt-wrap {
+      background: var(--white);
+      border-radius: var(--r-lg);
+      box-shadow: var(--sh-sm);
+      overflow: hidden;
+      flex: 1;
+    }
+
+    /* ── Grid ── */
+    .tt-grid {
+      display: grid;
+      grid-template-columns: 56px repeat(5, 1fr);
+      overflow-x: auto;
+      min-width: 600px;
+    }
+
+    .tt-corner {
+      background: var(--surface);
+      border-right: 1px solid var(--border);
+      border-bottom: 1px solid var(--border);
+    }
+
+    /* Day headers */
+    .tt-day-header {
+      padding: var(--sp-3) var(--sp-2);
+      background: var(--surface);
+      border-bottom: 1px solid var(--border);
+      border-right: 1px solid var(--border);
+      text-align: center;
+    }
+    .tt-day-header:last-child { border-right: none; }
+    .tt-day-header.tt-today-col { background: rgba(123,170,186,0.07); }
+
+    .tt-day-name {
+      font-size: 10px; font-weight: 600; letter-spacing: 0.8px;
+      text-transform: uppercase; color: var(--ink-faint);
+    }
+    .tt-day-date {
+      font-size: 20px; font-weight: 300; color: var(--navy);
+      line-height: 1.3; margin-top: 2px;
+    }
+    .tt-day-date.tt-today-date {
+      color: var(--teal); font-weight: 500;
+    }
+
+    /* Time column */
+    .tt-time {
+      border-right: 1px solid var(--border);
+      border-bottom: 1px solid var(--border);
+      padding: var(--sp-2) var(--sp-2);
+      height: 86px; display: flex; flex-direction: column;
+      align-items: flex-end; justify-content: flex-start;
+      padding-top: var(--sp-2); background: var(--surface);
+    }
+    .tt-period-nr  { font-size: 11px; font-weight: 600; color: var(--ink-faint); }
+    .tt-period-time { font-size: 10px; color: var(--ink-faint); opacity: 0.7; margin-top: 2px; }
+
+    /* Cells */
+    .tt-cell {
+      border-right: 1px solid var(--border);
+      border-bottom: 1px solid var(--border);
+      height: 86px; padding: var(--sp-1);
+      position: relative;
+    }
+    .tt-cell:last-child { border-right: none; }
+    .tt-cell.tt-today-col { background: rgba(123,170,186,0.04); }
+
+    /* Today marker line */
+    .tt-today-marker {
+      position: absolute; top: 0; left: 0; right: 0;
+      height: 2px; background: var(--teal);
+    }
+
+    /* Lesson block */
+    .tt-lesson {
+      border-radius: var(--r-sm);
+      padding: var(--sp-2) var(--sp-2);
+      height: calc(100% - 4px); margin: 2px;
+      cursor: pointer;
+      transition: box-shadow .12s, transform .12s;
+      display: flex; flex-direction: column;
+      border-left: 3px solid var(--teal);
+      position: relative; overflow: hidden;
+    }
+    .tt-lesson:hover { box-shadow: var(--sh-md); transform: translateY(-1px); }
+
+    .tt-lesson-repeat {
+      font-size: 9px; font-weight: 600; letter-spacing: 0.3px;
+      color: inherit; opacity: 0.6;
+      position: absolute; top: 3px; right: 4px;
+    }
+    .tt-lesson-subject { font-size: 12px; font-weight: 600; line-height: 1.3; color: var(--ink); }
+    .tt-lesson-class   { font-size: 11px; color: var(--ink-light); margin-top: 1px; }
+    .tt-lesson-room    { font-size: 10px; color: var(--ink-faint); margin-top: auto; }
+
+    /* Add button (hover) */
+    .tt-add-btn {
+      width: 100%; height: 100%;
+      border: 1.5px dashed transparent;
+      border-radius: var(--r-sm);
+      background: transparent; cursor: pointer;
+      display: flex; align-items: center; justify-content: center;
+      color: var(--ink-faint); transition: all .12s;
+      opacity: 0;
+    }
+    .tt-cell:hover .tt-add-btn {
+      opacity: 1;
+      border-color: var(--light-teal);
+      color: var(--teal);
+    }
+
+    /* Legend */
+    .tt-legend {
+      display: flex; flex-wrap: wrap; align-items: center; gap: var(--sp-2);
+      padding: var(--sp-3) var(--sp-5);
+      border-top: 1px solid var(--border);
+      background: var(--surface);
+    }
+    .legend-label { font-size: 11px; color: var(--ink-faint); margin-right: var(--sp-1); }
+    .legend-chip {
+      display: inline-flex; align-items: center;
+      padding: 2px 9px; border-radius: 20px;
+      font-size: 11px; font-weight: 500;
+    }
+    .chip-teal  { background: var(--light-teal); color: var(--navy); }
+    .chip-sand  { background: #EDD9C4; color: #7A5A3A; }
+    .chip-ghost { background: var(--surface); color: var(--ink-light); border: 1px solid var(--border); }
+
+    /* Loading skeleton */
+    .tt-loading { padding: var(--sp-5) 0; }
+    .skeleton-grid { display: grid; grid-template-columns: repeat(5, 1fr); gap: var(--sp-3); }
+    .skeleton-card {
+      height: 80px; border-radius: var(--r-md);
+      background: linear-gradient(90deg, var(--surface) 25%, var(--border) 50%, var(--surface) 75%);
+      background-size: 200% 100%;
+      animation: shimmer 1.4s infinite;
+    }
+    @keyframes shimmer { 0% { background-position: 200% 0; } 100% { background-position: -200% 0; } }
+
+    /* Empty state */
+    .tt-empty {
+      display: flex; flex-direction: column; align-items: center;
+      justify-content: center; padding: var(--sp-8) var(--sp-6);
+      text-align: center; gap: var(--sp-4);
+    }
+    .empty-icon { font-size: 48px; }
+    .tt-empty h2 { font-family: var(--font-display); font-size: 24px; color: var(--navy); font-weight: 400; margin: 0; }
+    .tt-empty p  { font-size: 14px; color: var(--ink-faint); margin: 0; }
+
+    /* ── Overlay ── */
+    .tt-overlay {
+      position: fixed; inset: 0;
+      background: rgba(28,43,58,.35);
+      z-index: 199;
+      animation: fadeIn .2s ease;
+    }
+    @keyframes fadeIn { from { opacity: 0 } to { opacity: 1 } }
+
+    /* ── Slide-in Panel ── */
+    .tt-panel {
+      position: fixed; top: 0; right: 0; bottom: 0;
+      width: 420px; max-width: 100vw;
+      background: var(--white);
+      box-shadow: var(--sh-lg);
+      z-index: 200;
+      transform: translateX(100%);
+      transition: transform .25s ease;
+    }
+    .tt-panel.open { transform: translateX(0); }
+
+    /* ── Responsive ── */
+    @media (max-width: 768px) {
+      .tt-page { padding: var(--sp-4) var(--sp-3); }
+      .week-label { min-width: 0; font-size: 13px; }
+      .tt-panel { width: 100vw; }
+      .tt-grid { min-width: 500px; }
+      .tt-day-date { font-size: 16px; }
+    }
+  `],
+})
+export class TimetableComponent implements OnInit {
+  private readonly timetableSvc = inject(TimetableService);
+  private readonly classSvc     = inject(ClassService);
+  private readonly subjectSvc   = inject(SubjectService);
+
+  // ── State ──────────────────────────────────────────────────────────────
+  readonly loading      = signal(true);
+  readonly allEntries   = signal<TimetableEntryDto[]>([]);
+  readonly classes      = signal<ClassDto[]>([]);
+  readonly subjects     = signal<SubjectDto[]>([]);
+  readonly currentMonday = signal(getMondayOfWeek());
+  readonly selectedYear  = signal(currentSchoolYear());
+  readonly panelOpen     = signal(false);
+  readonly editEntry     = signal<TimetableEntryDto | null>(null);
+  readonly prefillSlot   = signal<{ day: number; period: number } | null>(null);
+
+  // ── Computed ───────────────────────────────────────────────────────────
+  readonly weekInfo = computed<WeekInfo>(() => buildWeekInfo(this.currentMonday()));
+
+  readonly visibleEntries = computed(() =>
+    filterEntriesForWeek(this.allEntries(), this.weekInfo())
+  );
+
+  readonly periods = computed<number[]>(() => {
+    const max = Math.max(6, ...this.allEntries().map(e => e.period));
+    return Array.from({ length: max }, (_, i) => i + 1);
+  });
+
+  readonly hasBiweekly = computed(() =>
+    this.allEntries().some(e => e.repeatType === RepeatType.BIWEEKLY)
+  );
+
+  // ── Constants ──────────────────────────────────────────────────────────
+  readonly DAY_NAMES    = DAY_NAMES;
+  readonly PERIOD_TIMES = PERIOD_TIMES;
+  readonly days         = [1, 2, 3, 4, 5] as const;
+
+  readonly availableYears = this.buildYearOptions();
+
+  // ── Lifecycle ──────────────────────────────────────────────────────────
+  ngOnInit(): void {
+    this.load();
+    this.classSvc.getAll().subscribe(c => this.classes.set(c));
+    this.subjectSvc.getAll().subscribe(s => this.subjects.set(s));
+  }
+
+  private load(): void {
+    this.loading.set(true);
+    this.timetableSvc.getAll(this.selectedYear()).subscribe({
+      next:  e  => { this.allEntries.set(e); this.loading.set(false); },
+      error: () => this.loading.set(false),
+    });
+  }
+
+  // ── Week navigation ────────────────────────────────────────────────────
+  prevWeek(): void { this.currentMonday.update(d => addDays(d, -7)); }
+  nextWeek(): void { this.currentMonday.update(d => addDays(d,  7)); }
+  goToToday(): void { this.currentMonday.set(getMondayOfWeek()); }
+
+  onYearChange(event: Event): void {
+    this.selectedYear.set((event.target as HTMLSelectElement).value);
+    this.load();
+  }
+
+  // ── Grid helpers ───────────────────────────────────────────────────────
+  getDayDate(day: number): Date {
+    return dateOfDay(this.currentMonday(), day);
+  }
+
+  isDayToday(day: number): boolean {
+    return isToday(this.getDayDate(day));
+  }
+
+  entriesForSlot(day: number, period: number): TimetableEntryDto[] {
+    return this.visibleEntries().filter(e => e.dayOfWeek === day && e.period === period);
+  }
+
+  getRepeatLabel(entry: TimetableEntryDto): string {
+    return repeatLabel(entry.repeatType, entry.weekVariant, entry.semester);
+  }
+
+  hexToFaint = hexToFaint;
+
+  // ── Panel ──────────────────────────────────────────────────────────────
+  openPanel(day?: number, period?: number): void {
+    this.editEntry.set(null);
+    this.prefillSlot.set(day && period ? { day, period } : null);
+    this.panelOpen.set(true);
+  }
+
+  openEdit(entry: TimetableEntryDto): void {
+    this.editEntry.set(entry);
+    this.prefillSlot.set(null);
+    this.panelOpen.set(true);
+  }
+
+  closePanel(): void { this.panelOpen.set(false); }
+
+  onSaved(entry: TimetableEntryDto): void {
+    const list = this.allEntries();
+    const idx  = list.findIndex(e => e.id === entry.id);
+    if (idx >= 0) {
+      this.allEntries.set([...list.slice(0, idx), entry, ...list.slice(idx + 1)]);
+    } else {
+      this.allEntries.set([...list, entry]);
+    }
+    this.closePanel();
+  }
+
+  onDeleted(id: string): void {
+    this.allEntries.update(list => list.filter(e => e.id !== id));
+    this.closePanel();
+  }
+
+  // ── Helpers ────────────────────────────────────────────────────────────
+  private buildYearOptions(): string[] {
+    const now   = new Date();
+    const month = now.getMonth() + 1;
+    const curr  = month >= 9 ? now.getFullYear() : now.getFullYear() - 1;
+    const years: string[] = [];
+    for (let offset = 1; offset >= -3; offset--) {
+      const s = curr + offset;
+      years.push(`${s}/${String(s + 1).slice(-2)}`);
+    }
+    return years;
+  }
+}
+
+function addDays(date: Date, n: number): Date {
+  const d = new Date(date);
+  d.setDate(d.getDate() + n);
+  return d;
+}

--- a/apps/klara/src/app/features/timetable/timetable.component.ts
+++ b/apps/klara/src/app/features/timetable/timetable.component.ts
@@ -236,8 +236,6 @@ import {
   styles: [`
     .tt-page {
       padding: var(--sp-5) var(--sp-6);
-      min-height: calc(100vh - 0px);
-      display: flex; flex-direction: column;
     }
 
     /* ══════════════════════════════════════
@@ -365,7 +363,7 @@ import {
       background: var(--white);
       border-radius: var(--r-lg);
       box-shadow: var(--sh-sm);
-      overflow: hidden; flex: 1;
+      overflow: hidden; 
     }
 
     .tt-grid {

--- a/apps/klara/src/app/features/timetable/timetable.component.ts
+++ b/apps/klara/src/app/features/timetable/timetable.component.ts
@@ -435,7 +435,7 @@ import {
     .tt-grid {
       display: grid;
       grid-template-columns: 56px repeat(5, 1fr);
-      overflow-x: auto; min-width: 600px;
+      overflow-x: auto; 
     }
 
     .tt-corner {
@@ -615,6 +615,10 @@ import {
     }
     .tt-lesson-mobile-meta .tt-lesson-room  { font-size: 11px; }
     .tt-lesson-mobile-meta .tt-lesson-repeat { font-size: 10px; position: static; opacity: .6; }
+
+    .tt-grid-desktop {
+      min-width: 600px;
+    }
 
     /* ══════════════════════════════════════
        RESPONSIVE

--- a/apps/klara/src/app/features/timetable/timetable.service.ts
+++ b/apps/klara/src/app/features/timetable/timetable.service.ts
@@ -1,0 +1,31 @@
+import { Injectable, inject } from '@angular/core';
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import {
+  TimetableEntryDto,
+  CreateTimetableEntryDto,
+  UpdateTimetableEntryDto,
+} from '@app/domain';
+
+@Injectable({ providedIn: 'root' })
+export class TimetableService {
+  private readonly http = inject(HttpClient);
+  private readonly base = '/api/timetable';
+
+  getAll(schoolYear: string): Observable<TimetableEntryDto[]> {
+    const params = new HttpParams().set('schoolYear', schoolYear);
+    return this.http.get<TimetableEntryDto[]>(this.base, { params });
+  }
+
+  create(dto: CreateTimetableEntryDto): Observable<TimetableEntryDto> {
+    return this.http.post<TimetableEntryDto>(this.base, dto);
+  }
+
+  update(id: string, dto: UpdateTimetableEntryDto): Observable<TimetableEntryDto> {
+    return this.http.put<TimetableEntryDto>(`${this.base}/${id}`, dto);
+  }
+
+  remove(id: string): Observable<void> {
+    return this.http.delete<void>(`${this.base}/${id}`);
+  }
+}

--- a/apps/klara/src/app/features/timetable/week.utils.ts
+++ b/apps/klara/src/app/features/timetable/week.utils.ts
@@ -92,6 +92,14 @@ export function isToday(date: Date): boolean {
     && date.getFullYear() === now.getFullYear();
 }
 
+export function schoolYearBounds(schoolYear: string): { from: Date; to: Date } {
+  const startYear = parseInt(schoolYear.split('/')[0], 10);
+  return {
+    from: new Date(startYear,     8, 1),   // 1. September
+    to:   new Date(startYear + 1, 7, 31),  // 31. August
+  };
+}
+
 /**
  * Filtert Stundenplan-Einträge für eine konkrete Woche.
  * Berücksichtigt: repeatType, weekVariant, semester, onceDate, validFrom, validTo.
@@ -105,8 +113,12 @@ export function filterEntriesForWeek(
 
   return entries.filter(e => {
     // Gültigkeitszeitraum
-    if (e.validFrom && new Date(e.validFrom) > friday)      return false;
-    if (e.validTo   && new Date(e.validTo)   < week.mondayDate) return false;
+    const bounds = schoolYearBounds(e.schoolYear);
+    const from   = e.validFrom ? new Date(e.validFrom) : bounds.from;
+    const to     = e.validTo   ? new Date(e.validTo)   : bounds.to;
+
+    if (from > friday)          return false;
+    if (to   < week.mondayDate) return false;
 
     switch (e.repeatType) {
       case RepeatType.WEEKLY:

--- a/apps/klara/src/app/features/timetable/week.utils.ts
+++ b/apps/klara/src/app/features/timetable/week.utils.ts
@@ -1,0 +1,188 @@
+import { TimetableEntryDto } from '@app/domain';
+import { RepeatType, WeekVariant } from '@app/domain';
+
+export interface WeekInfo {
+  mondayDate: Date;
+  isoWeek:    number;
+  isWeekA:    boolean;
+  semester:   1 | 2;
+  label:      string;
+}
+
+/** Gibt den Montag der Woche zurück, in der `date` liegt */
+export function getMondayOfWeek(date: Date = new Date()): Date {
+  const d = new Date(date);
+  const day = d.getDay(); // 0 = So
+  const diff = day === 0 ? -6 : 1 - day;
+  d.setDate(d.getDate() + diff);
+  d.setHours(0, 0, 0, 0);
+  return d;
+}
+
+/** ISO-Kalenderwoche (1–53) */
+export function getISOWeek(date: Date): number {
+  const tmp = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+  const dayNum = tmp.getUTCDay() || 7;
+  tmp.setUTCDate(tmp.getUTCDate() + 4 - dayNum);
+  const yearStart = new Date(Date.UTC(tmp.getUTCFullYear(), 0, 1));
+  return Math.ceil((((tmp.getTime() - yearStart.getTime()) / 86400000) + 1) / 7);
+}
+
+/** Schuljahr als String, z.B. '2025/26' */
+export function currentSchoolYear(): string {
+  const now   = new Date();
+  const month = now.getMonth() + 1;
+  const start = month >= 9 ? now.getFullYear() : now.getFullYear() - 1;
+  return `${start}/${String(start + 1).slice(-2)}`;
+}
+
+/**
+ * Woche A oder B:
+ * KW 36 (erster möglicher Schulstart AT) gilt als Referenz-KW-A.
+ * Jede ungerade Differenz zur Referenz → Woche B.
+ */
+export function isWeekA(isoWeek: number): boolean {
+  const referenceWeekA = 36;
+  return ((isoWeek - referenceWeekA) % 2 + 2) % 2 === 0;
+}
+
+/** Aktuelles Semester (1 = Sep–Jan, 2 = Feb–Jun) */
+export function getSemester(date: Date): 1 | 2 {
+  const m = date.getMonth() + 1;
+  return m >= 9 || m <= 1 ? 1 : 2;
+}
+
+/** Vollständige WeekInfo für eine gegebene Montags-Datum */
+export function buildWeekInfo(monday: Date): WeekInfo {
+  const kw = getISOWeek(monday);
+  return {
+    mondayDate: monday,
+    isoWeek:    kw,
+    isWeekA:    isWeekA(kw),
+    semester:   getSemester(monday),
+    label:      formatWeekLabel(monday),
+  };
+}
+
+/** Lesbares Wochen-Label, z.B. "24. – 28. März 2026 · KW 13" */
+export function formatWeekLabel(monday: Date): string {
+  const friday = new Date(monday);
+  friday.setDate(friday.getDate() + 4);
+  const kw   = getISOWeek(monday);
+  const dFmt = new Intl.DateTimeFormat('de-AT', { day: 'numeric', month: 'long' });
+  const full = new Intl.DateTimeFormat('de-AT', { day: 'numeric', month: 'long', year: 'numeric' });
+  const from = monday.getMonth() === friday.getMonth()
+    ? `${monday.getDate()}.`
+    : dFmt.format(monday);
+  return `${from} – ${full.format(friday)} · KW ${kw}`;
+}
+
+/** Datum von Tag X (1=Mo…5=Fr) in einer Woche ab mondayDate */
+export function dateOfDay(monday: Date, dayOfWeek: number): Date {
+  const d = new Date(monday);
+  d.setDate(d.getDate() + (dayOfWeek - 1));
+  return d;
+}
+
+/** Prüft ob ein Datum heute ist */
+export function isToday(date: Date): boolean {
+  const now = new Date();
+  return date.getDate() === now.getDate()
+    && date.getMonth() === now.getMonth()
+    && date.getFullYear() === now.getFullYear();
+}
+
+/**
+ * Filtert Stundenplan-Einträge für eine konkrete Woche.
+ * Berücksichtigt: repeatType, weekVariant, semester, onceDate, validFrom, validTo.
+ */
+export function filterEntriesForWeek(
+  entries: TimetableEntryDto[],
+  week: WeekInfo,
+): TimetableEntryDto[] {
+  const friday = new Date(week.mondayDate);
+  friday.setDate(friday.getDate() + 4);
+
+  return entries.filter(e => {
+    // Gültigkeitszeitraum
+    if (e.validFrom && new Date(e.validFrom) > friday)      return false;
+    if (e.validTo   && new Date(e.validTo)   < week.mondayDate) return false;
+
+    switch (e.repeatType) {
+      case RepeatType.WEEKLY:
+        return true;
+
+      case RepeatType.BIWEEKLY: {
+        if (!e.weekVariant || e.weekVariant === WeekVariant.BOTH) return true;
+        return e.weekVariant === WeekVariant.A ? week.isWeekA : !week.isWeekA;
+      }
+
+      case RepeatType.SEMESTER:
+        return e.semester === week.semester;
+
+      case RepeatType.ONCE: {
+        if (!e.onceDate) return false;
+        const onceMonday = getMondayOfWeek(new Date(e.onceDate));
+        return onceMonday.getTime() === week.mondayDate.getTime();
+      }
+
+      default:
+        return false;
+    }
+  });
+}
+
+/** Gibt ein lesbares Repeat-Label zurück */
+export function repeatLabel(repeatType: RepeatType, weekVariant?: WeekVariant | null, semester?: number | null): string {
+  switch (repeatType) {
+    case RepeatType.WEEKLY:   return 'wöchentl.';
+    case RepeatType.BIWEEKLY:
+      if (weekVariant === WeekVariant.A)    return 'Woche A';
+      if (weekVariant === WeekVariant.B)    return 'Woche B';
+      return '2-wöchentl.';
+    case RepeatType.SEMESTER: return semester === 1 ? '1. Sem.' : '2. Sem.';
+    case RepeatType.ONCE:     return 'einmalig';
+    default:                  return '';
+  }
+}
+
+/** Hellt eine Hex-Farbe auf für Hintergrundnutzung (Opazität ~12%) */
+export function hexToFaint(hex: string | null): string {
+  if (!hex) return '#EEF4F7';
+  // Strip # and parse
+  const h = hex.replace('#', '');
+  const r = parseInt(h.slice(0, 2), 16);
+  const g = parseInt(h.slice(2, 4), 16);
+  const b = parseInt(h.slice(4, 6), 16);
+  return `rgba(${r}, ${g}, ${b}, 0.13)`;
+}
+
+/** Stundenzeiten für AT-Schulen (Stunde 1–10) */
+export const PERIOD_TIMES: Record<number, string> = {
+  1:  '7:55',
+  2:  '8:45',
+  3:  '9:40',
+  4:  '10:30',
+  5:  '11:20',
+  6:  '12:10',
+  7:  '13:05',
+  8:  '13:55',
+  9:  '14:45',
+  10: '15:35',
+};
+
+export const DAY_NAMES: Record<number, string> = {
+  1: 'Mo',
+  2: 'Di',
+  3: 'Mi',
+  4: 'Do',
+  5: 'Fr',
+};
+
+export const DAY_NAMES_LONG: Record<number, string> = {
+  1: 'Montag',
+  2: 'Dienstag',
+  3: 'Mittwoch',
+  4: 'Donnerstag',
+  5: 'Freitag',
+};

--- a/apps/klara/src/app/shell/app-shell.component.ts
+++ b/apps/klara/src/app/shell/app-shell.component.ts
@@ -39,10 +39,12 @@ import { AuthService } from '../auth/auth.service';
           <li>
             <a routerLink="/app" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}" class="nav-item" (click)="closeSidebar()">
               <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
-                <rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/>
-                <rect x="14" y="14" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/>
+                <rect x="3" y="4" width="18" height="18" rx="2" ry="2"/>
+                <line x1="16" y1="2" x2="16" y2="6"/>
+                <line x1="8" y1="2" x2="8" y2="6"/>
+                <line x1="3" y1="10" x2="21" y2="10"/>
               </svg>
-              Dashboard
+              Stundenplan
             </a>
           </li>
         </ul>

--- a/apps/server/project.json
+++ b/apps/server/project.json
@@ -8,9 +8,20 @@
     "build": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "webpack-cli build",
+        "commands": [
+          {
+            "command": "npx tsc -p tsconfig.typeorm.json --noEmit false",
+            "description": "Compile the TypeORM datasource and migrations before webpack copies them as runtime assets.",
+            "forwardAllArgs": false
+          },
+          {
+            "command": "webpack-cli build",
+            "forwardAllArgs": true
+          }
+        ],
         "args": ["--node-env=production"],
-        "cwd": "apps/server"
+        "cwd": "apps/server",
+        "parallel": false
       },
       "configurations": {
         "development": {

--- a/apps/server/src/app/app.module.ts
+++ b/apps/server/src/app/app.module.ts
@@ -15,6 +15,7 @@ import { SubjectModule } from './subject/subject.module';
 import { NoteModule } from './note/note.module';
 import { AssessmentModule } from './assessment/assessment.module';
 import { SeedModule } from './seed/seed.module';
+import { TimetableModule } from './timetable/timetable.module';
 
 // Migrations liegen nach dem Build als separate JS-Dateien in dist/apps/server/migrations/.
 // __dirname zeigt zur Laufzeit auf dist/apps/server/app/ → eine Ebene hoch.
@@ -89,6 +90,7 @@ const migrationsPath = join(__dirname, '..', 'migrations', '*.js');
     NoteModule,
     AssessmentModule,
     SeedModule,
+    TimetableModule,
   ],
   controllers: [AppController],
   providers: [AppService],

--- a/apps/server/src/app/app.module.ts
+++ b/apps/server/src/app/app.module.ts
@@ -74,7 +74,7 @@ const migrationsPath = join(__dirname, '..', 'migrations', '*.js');
           type: 'sqlite' as const,
           database: db?.sqlitePath ?? process.env.TYPEORM_DB ?? './klara.sqlite',
           autoLoadEntities: true,
-          synchronize: db?.synchronize,
+          synchronize: true,
           migrationsRun: db?.migrationsRun,
           migrations: [migrationsPath],
         };

--- a/apps/server/src/app/student/student.entity.ts
+++ b/apps/server/src/app/student/student.entity.ts
@@ -35,7 +35,7 @@ export class Student {
   @Column({ nullable: true })
   phone: string;
 
-  @Column({ type: 'char', length: 1, nullable: true })
+  @Column({ type: 'varchar', length: 1, nullable: true })
   gender: string;
 
   @Column({ nullable: true })

--- a/apps/server/src/app/timetable/timetable-entry.entity.ts
+++ b/apps/server/src/app/timetable/timetable-entry.entity.ts
@@ -1,0 +1,88 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  JoinColumn,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { RepeatType, WeekVariant } from '@app/domain';
+import { Teacher } from '../teacher/teacher.entity';
+import { Subject } from '../subject/subject.entity';
+import { Class } from '../class/class.entity';
+
+@Entity('timetable_entries')
+export class TimetableEntry {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @ManyToOne(() => Teacher, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'teacherId' })
+  teacher: Teacher;
+
+  @Column()
+  teacherId: string;
+
+  @ManyToOne(() => Subject, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'subjectId' })
+  subject: Subject;
+
+  @Column()
+  subjectId: string;
+
+  @ManyToOne(() => Class, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'classId' })
+  class: Class;
+
+  @Column()
+  classId: string;
+
+  /** 1 = Montag … 5 = Freitag */
+  @Column({ type: 'int' })
+  dayOfWeek: number;
+
+  /** Unterrichtsstunden-Nummer (1–10) */
+  @Column({ type: 'int' })
+  period: number;
+
+  @Column({ nullable: true })
+  room: string | null;
+
+  @Column({ type: 'varchar', default: RepeatType.WEEKLY })
+  repeatType: RepeatType;
+
+  /** Nur bei BIWEEKLY: 'A' | 'B' | 'BOTH' */
+  @Column({ type: 'varchar', nullable: true })
+  weekVariant: WeekVariant | null;
+
+  /** Nur bei SEMESTER: 1 | 2 */
+  @Column({ type: 'int', nullable: true })
+  semester: number | null;
+
+  /** Nur bei ONCE: konkretes Datum */
+  @Column({ type: 'date', nullable: true })
+  onceDate: Date | null;
+
+  /** Optionaler Gültigkeitsstart */
+  @Column({ type: 'date', nullable: true })
+  validFrom: Date | null;
+
+  /** Optionales Gültigkeitsende */
+  @Column({ type: 'date', nullable: true })
+  validTo: Date | null;
+
+  /** Hex-Farbe für die Darstellung im Stundenplan, z.B. '#5B8AC0' */
+  @Column({ nullable: true })
+  color: string | null;
+
+  /** Schuljahr, z.B. '2025/26' */
+  @Column()
+  schoolYear: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/apps/server/src/app/timetable/timetable-validation.dto.ts
+++ b/apps/server/src/app/timetable/timetable-validation.dto.ts
@@ -1,0 +1,137 @@
+import {
+  IsEnum, IsInt, IsOptional, IsString, IsUUID,
+  IsDateString, Max, MaxLength, Min, ValidateIf,
+} from 'class-validator';
+import { Type } from 'class-transformer';
+import { RepeatType, WeekVariant } from '@app/domain';
+
+export class CreateTimetableEntryValidationDto {
+  @IsUUID()
+  subjectId!: string;
+
+  @IsUUID()
+  classId!: string;
+
+  /** 1 = Montag … 5 = Freitag */
+  @IsInt()
+  @Min(1)
+  @Max(5)
+  @Type(() => Number)
+  dayOfWeek!: number;
+
+  /** Unterrichtsstunden-Nummer 1–10 */
+  @IsInt()
+  @Min(1)
+  @Max(10)
+  @Type(() => Number)
+  period!: number;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  room?: string;
+
+  @IsEnum(RepeatType)
+  repeatType!: RepeatType;
+
+  /** Nur bei BIWEEKLY Pflicht */
+  @ValidateIf(o => o.repeatType === RepeatType.BIWEEKLY)
+  @IsEnum(WeekVariant)
+  weekVariant?: WeekVariant;
+
+  /** Nur bei SEMESTER Pflicht */
+  @ValidateIf(o => o.repeatType === RepeatType.SEMESTER)
+  @IsInt()
+  @Min(1)
+  @Max(2)
+  @Type(() => Number)
+  semester?: number;
+
+  /** Nur bei ONCE Pflicht */
+  @ValidateIf(o => o.repeatType === RepeatType.ONCE)
+  @IsDateString()
+  onceDate?: string;
+
+  @IsOptional()
+  @IsDateString()
+  validFrom?: string;
+
+  @IsOptional()
+  @IsDateString()
+  validTo?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(20)
+  color?: string;
+
+  @IsString()
+  @MaxLength(10)
+  schoolYear!: string;
+}
+
+export class UpdateTimetableEntryValidationDto {
+  @IsOptional()
+  @IsUUID()
+  subjectId?: string;
+
+  @IsOptional()
+  @IsUUID()
+  classId?: string;
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(5)
+  @Type(() => Number)
+  dayOfWeek?: number;
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(10)
+  @Type(() => Number)
+  period?: number;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  room?: string;
+
+  @IsOptional()
+  @IsEnum(RepeatType)
+  repeatType?: RepeatType;
+
+  @IsOptional()
+  @IsEnum(WeekVariant)
+  weekVariant?: WeekVariant;
+
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(2)
+  @Type(() => Number)
+  semester?: number;
+
+  @IsOptional()
+  @IsDateString()
+  onceDate?: string;
+
+  @IsOptional()
+  @IsDateString()
+  validFrom?: string;
+
+  @IsOptional()
+  @IsDateString()
+  validTo?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(20)
+  color?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(10)
+  schoolYear?: string;
+}

--- a/apps/server/src/app/timetable/timetable.controller.ts
+++ b/apps/server/src/app/timetable/timetable.controller.ts
@@ -16,7 +16,10 @@ import { ApiBearerAuth, ApiOperation, ApiQuery, ApiTags } from '@nestjs/swagger'
 import { Request } from 'express';
 import { JwtAuthGuard } from '../auth/jwt-auth.guard';
 import { TimetableService } from './timetable.service';
-import { CreateTimetableEntryDto, UpdateTimetableEntryDto } from '@app/domain';
+import {
+  CreateTimetableEntryValidationDto,
+  UpdateTimetableEntryValidationDto,
+} from './timetable-validation.dto';
 
 function currentSchoolYear(): string {
   const now   = new Date();
@@ -46,7 +49,7 @@ export class TimetableController {
   /** POST /timetable */
   @Post()
   @ApiOperation({ summary: 'Neuen Stundeneintrag anlegen' })
-  create(@Body() dto: CreateTimetableEntryDto, @Req() req: Request) {
+  create(@Body() dto: CreateTimetableEntryValidationDto, @Req() req: Request) {
     return this.svc.create((req.user as any).id, dto);
   }
 
@@ -55,7 +58,7 @@ export class TimetableController {
   @ApiOperation({ summary: 'Stundeneintrag aktualisieren' })
   update(
     @Param('id') id: string,
-    @Body() dto: UpdateTimetableEntryDto,
+    @Body() dto: UpdateTimetableEntryValidationDto,
     @Req() req: Request,
   ) {
     return this.svc.update((req.user as any).id, id, dto);

--- a/apps/server/src/app/timetable/timetable.controller.ts
+++ b/apps/server/src/app/timetable/timetable.controller.ts
@@ -1,0 +1,71 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  HttpStatus,
+  Param,
+  Post,
+  Put,
+  Query,
+  Req,
+  UseGuards,
+} from '@nestjs/common';
+import { ApiBearerAuth, ApiOperation, ApiQuery, ApiTags } from '@nestjs/swagger';
+import { Request } from 'express';
+import { JwtAuthGuard } from '../auth/jwt-auth.guard';
+import { TimetableService } from './timetable.service';
+import { CreateTimetableEntryDto, UpdateTimetableEntryDto } from '@app/domain';
+
+function currentSchoolYear(): string {
+  const now   = new Date();
+  const month = now.getMonth() + 1;
+  const start = month >= 9 ? now.getFullYear() : now.getFullYear() - 1;
+  return `${start}/${String(start + 1).slice(-2)}`;
+}
+
+@ApiTags('timetable')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard)
+@Controller('timetable')
+export class TimetableController {
+  constructor(private readonly svc: TimetableService) {}
+
+  /** GET /timetable?schoolYear=2025/26 */
+  @Get()
+  @ApiOperation({ summary: 'Alle Stundenplan-Einträge der Lehrkraft für ein Schuljahr' })
+  @ApiQuery({ name: 'schoolYear', required: false, description: 'z.B. 2025/26' })
+  findAll(@Query('schoolYear') schoolYear: string, @Req() req: Request) {
+    return this.svc.findAll(
+      (req.user as any).id,
+      schoolYear ?? currentSchoolYear(),
+    );
+  }
+
+  /** POST /timetable */
+  @Post()
+  @ApiOperation({ summary: 'Neuen Stundeneintrag anlegen' })
+  create(@Body() dto: CreateTimetableEntryDto, @Req() req: Request) {
+    return this.svc.create((req.user as any).id, dto);
+  }
+
+  /** PUT /timetable/:id */
+  @Put(':id')
+  @ApiOperation({ summary: 'Stundeneintrag aktualisieren' })
+  update(
+    @Param('id') id: string,
+    @Body() dto: UpdateTimetableEntryDto,
+    @Req() req: Request,
+  ) {
+    return this.svc.update((req.user as any).id, id, dto);
+  }
+
+  /** DELETE /timetable/:id */
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  @ApiOperation({ summary: 'Stundeneintrag löschen' })
+  remove(@Param('id') id: string, @Req() req: Request) {
+    return this.svc.remove((req.user as any).id, id);
+  }
+}

--- a/apps/server/src/app/timetable/timetable.module.ts
+++ b/apps/server/src/app/timetable/timetable.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { TimetableEntry } from './timetable-entry.entity';
+import { TimetableService } from './timetable.service';
+import { TimetableController } from './timetable.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([TimetableEntry])],
+  providers: [TimetableService],
+  controllers: [TimetableController],
+})
+export class TimetableModule {}

--- a/apps/server/src/app/timetable/timetable.service.ts
+++ b/apps/server/src/app/timetable/timetable.service.ts
@@ -29,7 +29,8 @@ export class TimetableService {
     dto: CreateTimetableEntryDto,
   ): Promise<TimetableEntryDto> {
     const entry = this.repo.create({ ...dto, teacherId });
-    return this.toDto(await this.repo.save(entry));
+    const newEntry = await this.repo.save(entry);
+    return this.toDto(await this.findOwned(teacherId, newEntry.id));
   }
 
   async update(
@@ -39,7 +40,8 @@ export class TimetableService {
   ): Promise<TimetableEntryDto> {
     const entry = await this.findOwned(teacherId, id);
     Object.assign(entry, dto);
-    return this.toDto(await this.repo.save(entry));
+    await this.repo.save(entry);
+    return this.toDto(await this.findOwned(teacherId, entry.id));
   }
 
   async remove(teacherId: string, id: string): Promise<void> {

--- a/apps/server/src/app/timetable/timetable.service.ts
+++ b/apps/server/src/app/timetable/timetable.service.ts
@@ -1,0 +1,84 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { TimetableEntry } from './timetable-entry.entity';
+import {
+  TimetableEntryDto,
+  CreateTimetableEntryDto,
+  UpdateTimetableEntryDto,
+} from '@app/domain';
+
+@Injectable()
+export class TimetableService {
+  constructor(
+    @InjectRepository(TimetableEntry)
+    private readonly repo: Repository<TimetableEntry>,
+  ) {}
+
+  async findAll(teacherId: string, schoolYear: string): Promise<TimetableEntryDto[]> {
+    const entries = await this.repo.find({
+      where: { teacherId, schoolYear },
+      relations: ['subject', 'class'],
+      order: { dayOfWeek: 'ASC', period: 'ASC' },
+    });
+    return entries.map((e) => this.toDto(e));
+  }
+
+  async create(
+    teacherId: string,
+    dto: CreateTimetableEntryDto,
+  ): Promise<TimetableEntryDto> {
+    const entry = this.repo.create({ ...dto, teacherId });
+    return this.toDto(await this.repo.save(entry));
+  }
+
+  async update(
+    teacherId: string,
+    id: string,
+    dto: UpdateTimetableEntryDto,
+  ): Promise<TimetableEntryDto> {
+    const entry = await this.findOwned(teacherId, id);
+    Object.assign(entry, dto);
+    return this.toDto(await this.repo.save(entry));
+  }
+
+  async remove(teacherId: string, id: string): Promise<void> {
+    const entry = await this.findOwned(teacherId, id);
+    await this.repo.remove(entry);
+  }
+
+  // ── Private helpers ────────────────────────────────────────────────────────
+
+  private async findOwned(teacherId: string, id: string): Promise<TimetableEntry> {
+    const entry = await this.repo.findOne({
+      where: { id, teacherId },
+      relations: ['subject', 'class'],
+    });
+    if (!entry) throw new NotFoundException('Stundeneintrag nicht gefunden');
+    return entry;
+  }
+
+  private toDto(e: TimetableEntry): TimetableEntryDto {
+    return {
+      id:          e.id,
+      teacherId:   e.teacherId,
+      subjectId:   e.subjectId,
+      subjectName: e.subject?.name ?? '',
+      classId:     e.classId,
+      className:   e.class?.name ?? '',
+      dayOfWeek:   e.dayOfWeek,
+      period:      e.period,
+      room:        e.room ?? null,
+      repeatType:  e.repeatType,
+      weekVariant: e.weekVariant ?? null,
+      semester:    e.semester ?? null,
+      onceDate:    e.onceDate ? (e.onceDate as Date).toISOString().slice(0, 10) : null,
+      validFrom:   e.validFrom ? (e.validFrom as Date).toISOString().slice(0, 10) : null,
+      validTo:     e.validTo ? (e.validTo as Date).toISOString().slice(0, 10) : null,
+      color:       e.color ?? null,
+      schoolYear:  e.schoolYear,
+      createdAt:   e.createdAt.toISOString(),
+      updatedAt:   e.updatedAt.toISOString(),
+    };
+  }
+}

--- a/apps/server/src/migrations/1773590000000-AddStudentGender.ts
+++ b/apps/server/src/migrations/1773590000000-AddStudentGender.ts
@@ -12,7 +12,7 @@ export class AddStudentGender1773590000000 implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<void> {
     await queryRunner.query(`
       ALTER TABLE "students"
-        ADD COLUMN IF NOT EXISTS "gender" character(1)
+        ADD COLUMN IF NOT EXISTS "gender" varchar(1)
     `);
   }
 

--- a/apps/server/src/migrations/1773610000000-AddTimetableEntries.ts
+++ b/apps/server/src/migrations/1773610000000-AddTimetableEntries.ts
@@ -1,0 +1,67 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+/**
+ * Fügt die timetable_entries-Tabelle hinzu.
+ *
+ * Speichert Stundenplan-Regeln pro Lehrkraft:
+ *   - Fach, Klasse, Tag, Stunde, Raum
+ *   - Wiederholungstyp: WEEKLY | BIWEEKLY | SEMESTER | ONCE
+ *   - A/B-Wochen-Variante (nur bei BIWEEKLY)
+ *   - Semester 1/2 (nur bei SEMESTER)
+ *   - Konkretes Datum (nur bei ONCE)
+ *   - Optionaler Gültigkeitszeitraum (validFrom / validTo)
+ *   - Hex-Farbe für die Darstellung
+ *
+ * Strategie: IF NOT EXISTS – sicher auf bestehenden Datenbanken.
+ */
+export class AddTimetableEntries1773610000000 implements MigrationInterface {
+  name = 'AddTimetableEntries1773610000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS "timetable_entries" (
+        "id"          uuid              NOT NULL DEFAULT uuid_generate_v4(),
+        "teacherId"   uuid              NOT NULL,
+        "subjectId"   uuid              NOT NULL,
+        "classId"     uuid              NOT NULL,
+        "dayOfWeek"   integer           NOT NULL,
+        "period"      integer           NOT NULL,
+        "room"        character varying,
+        "repeatType"  character varying NOT NULL DEFAULT 'WEEKLY',
+        "weekVariant" character varying,
+        "semester"    integer,
+        "onceDate"    date,
+        "validFrom"   date,
+        "validTo"     date,
+        "color"       character varying,
+        "schoolYear"  character varying NOT NULL,
+        "createdAt"   TIMESTAMP         NOT NULL DEFAULT now(),
+        "updatedAt"   TIMESTAMP         NOT NULL DEFAULT now(),
+        CONSTRAINT "PK_timetable_entries" PRIMARY KEY ("id"),
+        CONSTRAINT "FK_timetable_entries_teacher"
+          FOREIGN KEY ("teacherId") REFERENCES "teachers"("id") ON DELETE CASCADE,
+        CONSTRAINT "FK_timetable_entries_subject"
+          FOREIGN KEY ("subjectId") REFERENCES "subjects"("id") ON DELETE CASCADE,
+        CONSTRAINT "FK_timetable_entries_class"
+          FOREIGN KEY ("classId") REFERENCES "classes"("id") ON DELETE CASCADE
+      )
+    `);
+
+    // Indizes für häufige Abfragen (Lehrkraft + Schuljahr, Lehrkraft + Tag)
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_timetable_teacher_year"
+        ON "timetable_entries" ("teacherId", "schoolYear")
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS "IDX_timetable_teacher_day"
+        ON "timetable_entries" ("teacherId", "dayOfWeek")
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_timetable_teacher_day"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "IDX_timetable_teacher_year"`);
+    await queryRunner.query(`DROP TABLE IF EXISTS "timetable_entries"`);
+  }
+}

--- a/libs/domain/src/dtos/index.ts
+++ b/libs/domain/src/dtos/index.ts
@@ -5,3 +5,4 @@ export * from './class.dto';
 export * from './note.dto';
 // Import DTOs are part of student.dto.ts — already exported via student.dto.ts
 export * from './assessment.dto';
+export * from './timetable.dto';

--- a/libs/domain/src/dtos/timetable.dto.ts
+++ b/libs/domain/src/dtos/timetable.dto.ts
@@ -1,0 +1,81 @@
+import { RepeatType, WeekVariant } from '../enums';
+
+// ── Create DTO ──────────────────────────────────────────────────────────────
+
+export class CreateTimetableEntryDto {
+  subjectId!: string;
+  classId!: string;
+
+  /** 1 = Montag … 5 = Freitag */
+  dayOfWeek!: number;
+
+  /** Unterrichtsstunden-Nummer (1–10) */
+  period!: number;
+
+  room?: string;
+
+  repeatType!: RepeatType;
+
+  /** Nur bei BIWEEKLY: 'A' | 'B' | 'BOTH' */
+  weekVariant?: WeekVariant;
+
+  /** Nur bei SEMESTER: 1 | 2 */
+  semester?: number;
+
+  /** Nur bei ONCE: ISO-Datum (YYYY-MM-DD) */
+  onceDate?: string;
+
+  /** Optionaler Gültigkeitsstart (ISO-Datum) */
+  validFrom?: string;
+
+  /** Optionales Gültigkeitsende (ISO-Datum) */
+  validTo?: string;
+
+  /** Hex-Farbe z.B. '#5B8AC0' */
+  color?: string;
+
+  /** z.B. '2025/26' */
+  schoolYear!: string;
+}
+
+// ── Update DTO ──────────────────────────────────────────────────────────────
+
+export class UpdateTimetableEntryDto {
+  subjectId?: string;
+  classId?: string;
+  dayOfWeek?: number;
+  period?: number;
+  room?: string;
+  repeatType?: RepeatType;
+  weekVariant?: WeekVariant;
+  semester?: number;
+  onceDate?: string;
+  validFrom?: string;
+  validTo?: string;
+  color?: string;
+  schoolYear?: string;
+}
+
+// ── Response DTO ─────────────────────────────────────────────────────────────
+
+export class TimetableEntryDto {
+  id!: string;
+  teacherId!: string;
+  subjectId!: string;
+  subjectName!: string;
+  classId!: string;
+  className!: string;
+  dayOfWeek!: number;
+  period!: number;
+  room!: string | null;
+  repeatType!: RepeatType;
+  weekVariant!: WeekVariant | null;
+  semester!: number | null;
+  onceDate!: string | null;
+  validFrom!: string | null;
+  validTo!: string | null;
+  color!: string | null;
+  schoolYear!: string;
+  createdAt!: string;
+  updatedAt!: string;
+}

--- a/libs/domain/src/enums/index.ts
+++ b/libs/domain/src/enums/index.ts
@@ -23,3 +23,16 @@ export enum AssessmentSchema {
   POINTS        = 'POINTS',        // freie Punkte
   PASS_FAIL     = 'PASS_FAIL',     // Bestanden/Nicht bestanden
 }
+
+export enum RepeatType {
+  WEEKLY    = 'WEEKLY',     // Jede Woche
+  BIWEEKLY  = 'BIWEEKLY',  // Jede zweite Woche (A/B-Wochen)
+  SEMESTER  = 'SEMESTER',  // Nur 1. oder 2. Semester
+  ONCE      = 'ONCE',      // Einmaliger Termin
+}
+
+export enum WeekVariant {
+  A    = 'A',    // Nur Woche A
+  B    = 'B',    // Nur Woche B
+  BOTH = 'BOTH', // Beide Wochen (A + B)
+}


### PR DESCRIPTION
Backend:
- RepeatType + WeekVariant Enums in libs/domain
- TimetableEntryDto, CreateTimetableEntryDto, UpdateTimetableEntryDto
- TimetableEntry Entity (timetable_entries Tabelle)
- TimetableService mit Ownership-Prüfung
- TimetableController (GET/POST/PUT/DELETE /timetable)
- TimetableModule registriert in AppModule
- Migration 1773610000000-AddTimetableEntries (IF NOT EXISTS + Indizes)

Frontend:
- TimetableService (/api/timetable)
- week.utils.ts (getMondayOfWeek, filterEntriesForWeek, repeatLabel, ...)
- TimetableEntryFormComponent (Slide-in Panel, alle 4 Wiederholungstypen)
- TimetableComponent (Wochenraster Mo–Fr, Wochennavigation, A/B-Woche)
- Route /app → TimetableComponent (ehemaliges Dashboard → /app/klassen-uebersicht)
- Sidebar: Dashboard → Stundenplan mit Kalender-Icon